### PR TITLE
[PAXWEB-803] Updating or uninstalling WAB bundle doesn't free classes. Fixes for 3.1.X

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainer.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainer.java
@@ -270,9 +270,19 @@ public interface WebContainer extends HttpService {
             Dictionary<String,?> initparams,
             HttpContext httpContext );
 
-    /**
-  	 * Registers a servlet filter.
+	/**
+	 * Unregister a previously registered servlet by it's name.
 	 * 
+	 * @param servletName the servlet identified by it's name.
+	 * 
+	 * @throws IllegalArgumentException
+	 *             if the servlet is null
+	 * 
+	 */
+	void unregisterServlet(String servletName);
+        
+        /**
+  	 * Registers a servlet filter.	 
 	 * @param filter
 	 *            a servlet filter class. If null an IllegalArgumentException is
 	 *            thrown.

--- a/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/UnregisterWebAppVisitorWC.java
+++ b/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/UnregisterWebAppVisitorWC.java
@@ -147,13 +147,20 @@ class UnregisterWebAppVisitorWC implements WebAppVisitor {
 	public void visit(final WebAppFilter webAppFilter) {
 		NullArgumentException.validateNotNull(webAppFilter, "Web app filter");
 		final Filter filter = webAppFilter.getFilter();
+                final String filterName;
 		if (filter != null) {
 			try {
 				webContainer.unregisterFilter(filter);
 			} catch (Exception ignore) { // CHECKSTYLE:SKIP
 				LOG.error("Unregistration exception. Skipping.", ignore);
 			}
-		}
+		}else if ((filterName = webAppFilter.getFilterName()) != null) {
+                        try {
+				webContainer.unregisterFilter(filterName);
+			} catch (Exception ignore) { // CHECKSTYLE:SKIP
+				LOG.error("Unregistration exception. Skipping.", ignore);
+			}
+                }
 	}
 
 	/**

--- a/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/UnregisterWebAppVisitorWC.java
+++ b/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/UnregisterWebAppVisitorWC.java
@@ -119,6 +119,7 @@ class UnregisterWebAppVisitorWC implements WebAppVisitor {
 		NullArgumentException.validateNotNull(webAppServlet, "Web app servlet");
 		final Class<? extends Servlet> servletClass = webAppServlet
 				.getServletClass();
+                final String servletName;
 		if (servletClass != null) {
 			try {
 				webContainer.unregisterServlets(servletClass);
@@ -126,7 +127,14 @@ class UnregisterWebAppVisitorWC implements WebAppVisitor {
 			} catch (Exception ignore) { // CHECKSTYLE:SKIP
 				LOG.error("Unregistration exception. Skipping.", ignore);
 			}
-		}
+		}else if ((servletName = webAppServlet.getServletName()) != null) {
+                        try {
+				webContainer.unregisterServlet(servletName);
+				webAppServlet.setServletClass(null);
+			} catch (Exception ignore) { // CHECKSTYLE:SKIP
+				LOG.error("Unregistration exception. Skipping.", ignore);
+			}
+                }
 	}
 
 	/**

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceProxy.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceProxy.java
@@ -134,6 +134,12 @@ public class HttpServiceProxy implements StoppableHttpService {
 		delegate.unregisterServlet(servlet);
 	}
 
+	@Override
+	public void unregisterServlet(String servletName) {
+		LOG.debug("Unregistering servlet with name [" + servletName + "]");
+		delegate.unregisterServlet(servletName);
+	}
+	
 	/**
 	 * @see org.ops4j.pax.web.service.WebContainer#registerServlet(java.lang.Class,
 	 *      java.lang.String[], java.util.Dictionary,

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStarted.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStarted.java
@@ -365,6 +365,17 @@ class HttpServiceStarted implements StoppableHttpService {
 			servletEvent(ServletEvent.UNDEPLOYED, serviceBundle, model);
 		}
 	}
+	
+	@Override
+	public void unregisterServlet(String servletName) {
+		ServletModel model = serviceModel.removeServlet(servletName);
+		if (model != null) {
+			servletEvent(ServletEvent.UNDEPLOYING, serviceBundle, model);
+			serverModel.removeServletModel(model);
+			serverController.removeServlet(model);
+			servletEvent(ServletEvent.UNDEPLOYED, serviceBundle, model);
+		}
+	}
 
 	@Override
 	public void registerServlet(Class<? extends Servlet> servletClass,

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStopped.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStopped.java
@@ -130,6 +130,17 @@ class HttpServiceStopped implements StoppableHttpService {
 		LOG.warn("Http service has already been stopped");
 	}
 
+
+	/**
+	 * Does nothing.
+	 * 
+	 * @see WebContainer#unregisterServlet(Servlet)
+	 */
+	@Override
+	public void unregisterServlet(final String servletName) {
+		LOG.warn("Http service has already been stopped");
+	}
+	
 	/**
 	 * Does nothing.
 	 * 

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/ServiceModel.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/ServiceModel.java
@@ -91,11 +91,30 @@ public class ServiceModel {
 		servletModels.remove(servlet);
 		return model;
 	}
+	
+	public synchronized ServletModel removeServlet(final String servletName) {
+		ServletModel model = findServletModel(servletName);
+		if (model == null) {
+			throw new IllegalArgumentException("Servlet with name ["+servletName+"] is currently not registered in any context");
+		}
+		Servlet servlet = model.getServlet();
+		servletModels.remove(servlet);
+		return model;
+	}
 
 	private synchronized ServletModel findServletModel(Servlet servlet) {
 		for (ServletModel servletModel : servletModels) {
 			if (servletModel.getServlet() != null
 					&& servletModel.getServlet().equals(servlet)) {
+				return servletModel;
+			}
+		}
+		return null;
+	}
+	
+	private synchronized ServletModel findServletModel(String servletName) {
+		for (ServletModel servletModel : servletModels) {
+			if (servletModel.getName() != null && servletModel.getName().equalsIgnoreCase(servletName)) {
 				return servletModel;
 			}
 		}

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/ServiceModel.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/ServiceModel.java
@@ -16,15 +16,12 @@
  */
 package org.ops4j.pax.web.service.spi.model;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.servlet.Filter;
@@ -88,7 +85,7 @@ public class ServiceModel {
 			throw new IllegalArgumentException("Servlet [" + servlet
 					+ " is not currently registered in any context");
 		}
-		servletModels.remove(servlet);
+		servletModels.remove(model);
 		return model;
 	}
 	
@@ -97,8 +94,7 @@ public class ServiceModel {
 		if (model == null) {
 			throw new IllegalArgumentException("Servlet with name ["+servletName+"] is currently not registered in any context");
 		}
-		Servlet servlet = model.getServlet();
-		servletModels.remove(servlet);
+		servletModels.remove(model);
 		return model;
 	}
 
@@ -190,7 +186,6 @@ public class ServiceModel {
 	}
 
 	public synchronized FilterModel removeFilter(final Filter filter) {
-		final FilterModel model;
 		Set<FilterModel> models = findFilterModels(filter);
 		if (models == null || models.isEmpty()) {
 			throw new IllegalArgumentException("Filter [" + filter


### PR DESCRIPTION
Those are simple fixes for 3.1.X;
- servlets hasn't been removed because servlet's model doesn't contain servlet class
- other small fixes
I'll add this to 4.X branches