### PR TITLE
[PAXWEB-898] - Add missing import packages for SSL

### DIFF
--- a/pax-web-jetty-bundle/pom.xml
+++ b/pax-web-jetty-bundle/pom.xml
@@ -47,6 +47,8 @@
 				javax.security.auth.callback,
 				javax.security.auth.login,
 				javax.servlet.jsp-api; version="[2.2,3)"; resolution:=optional,
+                javax.net.ssl; resolution:=optional,
+                javax.security.cert; resolution:=optional,
 				javax.xml.parsers,
 				org.apache.commons.logging,
 				org.apache.el; version="2.2"; resolution:=optional,

--- a/pax-web-jetty/pom.xml
+++ b/pax-web-jetty/pom.xml
@@ -48,6 +48,8 @@
 							javax.security.auth.login,
 							javax.servlet.jsp-api; version="[2.2,3)"; resolution:=optional,
 							javax.servlet.*; version="[2.3.0,4.0.0)",
+							javax.net.ssl; resolution:=optional,
+							javax.security.cert; resolution:=optional,
 							javax.xml.parsers,
 							org.eclipse.jetty.jaas; version="[7.1.0,10.0.0)";resolution:=optional,
 							org.eclipse.jetty.jmx;version="[7.1.0,10.0.0)"; resolution:=optional,


### PR DESCRIPTION
See https://ops4j1.jira.com/browse/PAXWEB-898

This adds the missing package imports again.