### PR TITLE
[PAXWEB-911] - Performance issue in ResourceServlet that calls twice getResource()

### DIFF
--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ResourceServlet.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ResourceServlet.java
@@ -179,9 +179,15 @@ class ResourceServlet extends HttpServlet implements ResourceFactory {
 			return;
 		}
 
-		// For Performanceimprovements turn caching on
-		// final Resource resource = ResourceEx.newResource(url, true);
-		final Resource resource = getResource(mapping);
+		Resource resource;
+		try {
+			// For Performance improvements turn caching on
+			resource = ResourceEx.newResource(url, true);
+		} catch (IOException e) {
+			log("failed to retrieve Resource for URL:" + url, e);
+			resource = null;
+		}
+
 		try {
 
 			if ((resource == null || !resource.exists()) && !endsWithSlash) {
@@ -384,6 +390,7 @@ class ResourceServlet extends HttpServlet implements ResourceFactory {
 		}
 
 		try {
+			// For Performance improvements turn caching on
 			return ResourceEx.newResource(url, true);
 		} catch (IOException e) {
 			log("failed to retrieve Resource for URL:" + url, e);


### PR DESCRIPTION
See https://ops4j1.jira.com/browse/PAXWEB-911