### PR TITLE
SSL Improvements

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
@@ -71,9 +71,19 @@ public interface WebContainerConstants { //CHECKSTYLE:SKIP
     String PROPERTY_SSL_KEYSTORE_TYPE = PID + ".ssl.keystore.type";
     String PROPERTY_SSL_PASSWORD = PID + ".ssl.password";
     String PROPERTY_SSL_KEYPASSWORD = PID + ".ssl.keypassword";
+    String PROPERTY_SSL_KEY_ALIAS = PID + ".ssl.key.alias";
+
+    String PROPERTY_SSL_TRUST_STORE = PID + ".ssl.truststore";
+    String PROPERTY_SSL_TRUST_STORE_PASSWORD = PID + ".ssl.truststore.password";
+    String PROPERTY_SSL_TRUST_STORE_TYPE = PID + ".ssl.truststore.type";
 
     String PROPERTY_SSL_CLIENT_AUTH_WANTED = PID + ".ssl.clientauthwanted";
     String PROPERTY_SSL_CLIENT_AUTH_NEEDED = PID + ".ssl.clientauthneeded";
+
+    String PROPERTY_PROTOCOLS_INCLUDED = PID + ".ssl.protocols.included";
+    String PROPERTY_PROTOCOLS_EXCLUDED = PID + ".ssl.protocols.excluded";
+    String PROPERTY_CIPHERSUITES_INCLUDED = PID + ".ssl.ciphersuites.included";
+    String PROPERTY_CIPHERSUITES_EXCLUDED = PID + ".ssl.ciphersuites.excluded";
 
     String PROPERTY_SESSION_TIMEOUT = PID + ".session.timeout";
     String PROPERTY_SESSION_COOKIE = PID + ".session.cookie";

--- a/pax-web-jetty/pom.xml
+++ b/pax-web-jetty/pom.xml
@@ -39,6 +39,7 @@
 							org.ops4j.pax.web.service; version="${project.version}",
 							org.ops4j.pax.web.service.spi.*; version="${project.version}",
 							org.ops4j.pax.swissbox.*,
+							javax.net.ssl,
 							javax.security.auth,
 							javax.security.auth.callback,
 							javax.security.auth.login,

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactory.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactory.java
@@ -16,6 +16,8 @@
  */
 package org.ops4j.pax.web.service.jetty.internal;
 
+import java.util.List;
+
 import org.eclipse.jetty.server.Connector;
 
 public interface JettyFactory {
@@ -40,6 +42,24 @@ public interface JettyFactory {
 	 *            keystore password.
 	 * @param host
 	 *            the address on which the secure port should listen
+	 * @param sslKeystoreType
+	 *            the SSL/TLS keystore type (e.g. jks, jceks, bks).
+	 * @param sslKeyAlias
+	 *            the alias of the SSL/TLS private key entry in the keystore.
+	 * @param isClientAuthNeeded
+	 *            true if the server requires client certificate authentication.
+	 * @param isClientAuthWanted
+	 *            true if the server accepts client certificate authentication.
+	 * @param isClientAuthWanted
+	 *            true if the server should use a non-blocking IO (NIO) connector.
+	 * @param cipherSuiteIncluded
+	 *            list of SSL/TLS cipher suites that are acceptable.
+	 * @param cipherSuiteExcluded
+	 *            list of SSL/TLS cipher suites that are not acceptable.
+	 * @param protocolsIncluded
+	 *            list of SSL/TLS protocols that are acceptable.
+	 * @param protocolsExcluded
+	 *            list of SSL/TLS protocols that are not acceptable.
 	 * 
 	 * @return a secure connector
 	 * 
@@ -47,7 +67,10 @@ public interface JettyFactory {
 	 */
 	Connector createSecureConnector(String name, int port, String sslKeystore,
 			String sslPassword, String sslKeyPassword, String host,
-			String sslKeystoreType, boolean isClientAuthNeeded,
-			boolean isClientAuthWanted, boolean useNIO);
+			String sslKeystoreType, String sslKeyAlias,
+			String trustStore, String trustStorePassword, String trustStoreType,
+			boolean isClientAuthNeeded, boolean isClientAuthWanted, boolean useNIO,
+			List<String> cipherSuiteIncluded, List<String> cipherSuiteExcluded,
+			List<String> protocolsIncluded, List<String> protocolsExcluded);
 
 }

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactoryImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactoryImpl.java
@@ -16,6 +16,13 @@
  */
 package org.ops4j.pax.web.service.jetty.internal;
 
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.bio.SocketConnector;
 import org.eclipse.jetty.server.nio.SelectChannelConnector;
@@ -90,8 +97,11 @@ class JettyFactoryImpl implements JettyFactory {
 	public Connector createSecureConnector(final String name, final int port,
 			final String sslKeystore, final String sslPassword,
 			final String sslKeyPassword, final String host,
-			final String sslKeystoreType, final boolean isClientAuthNeeded,
-			final boolean isClientAuthWanted, final boolean useNIO) {
+			final String sslKeystoreType, String sslKeyAlias,
+			String trustStore, String trustStorePassword, String trustStoreType,
+			boolean isClientAuthNeeded, boolean isClientAuthWanted, boolean useNIO,
+			List<String> cipherSuitesIncluded, List<String> cipherSuitesExcluded,
+			List<String> protocolsIncluded, List<String> protocolsExcluded) {
 		SslContextFactory sslContextFactory = new SslContextFactory(sslKeystore); // TODO:
 																					// PAXWEB-339
 																					// configurable
@@ -102,6 +112,70 @@ class JettyFactoryImpl implements JettyFactory {
 		sslContextFactory.setWantClientAuth(isClientAuthWanted);
 		if (sslKeystoreType != null) {
 			sslContextFactory.setKeyStoreType(sslKeystoreType);
+		}
+		// Java key stores may contain more than one private key entry.
+		// Specifying the alias tells jetty which one to use.
+		if ( (null != sslKeyAlias) && (!"".equals(sslKeyAlias)) ) {
+			sslContextFactory.setCertAlias(sslKeyAlias);
+		}
+
+		// Quite often it is useful to use a certificate trust store other than the JVM default.
+		if ( (null != trustStore) && (!"".equals(trustStore)) ) {
+			sslContextFactory.setTrustStore(trustStore);
+		}
+		if ( (null != trustStorePassword) && (!"".equals(trustStorePassword))) {
+			sslContextFactory.setTrustStorePassword(trustStorePassword);
+		}
+		if ( (null != trustStoreType) && (!"".equals(trustStoreType)) ) {
+			sslContextFactory.setTrustStoreType(trustStoreType);
+		}
+
+		// In light of well-known attacks against weak encryption algorithms such as RC4,
+		// it is usefull to be able to include or exclude certain ciphersuites.
+		// Due to the overwhelming number of cipher suites using regex to specify inclusions
+		// and exclusions greatly simplifies configuration.
+		final String[] cipherSuites;
+		try {
+			SSLContext context = SSLContext.getDefault();
+			SSLSocketFactory sf = context.getSocketFactory();
+			cipherSuites = sf.getSupportedCipherSuites();
+		}
+		catch (NoSuchAlgorithmException e) {
+
+			throw new RuntimeException("Failed to get supported cipher suites.", e);
+		}
+
+		if (cipherSuitesIncluded != null && !cipherSuitesIncluded.isEmpty()) {
+			final List<String> cipherSuitesToInclude = new ArrayList<String>();
+			for (final String cipherSuite : cipherSuites) {
+				for (final String includeRegex : cipherSuitesIncluded) {
+					if (cipherSuite.matches(includeRegex)) {
+						cipherSuitesToInclude.add(cipherSuite);
+					}
+				}
+			}
+			sslContextFactory.setIncludeCipherSuites(cipherSuitesToInclude.toArray(new String[cipherSuitesToInclude.size()]));
+		}
+
+		if (cipherSuitesExcluded != null && !cipherSuitesExcluded.isEmpty()) {
+			final List<String> cipherSuitesToExclude = new ArrayList<String>();
+			for (final String cipherSuite : cipherSuites) {
+				for (final String excludeRegex : cipherSuitesExcluded) {
+					if (cipherSuite.matches(excludeRegex)) {
+						cipherSuitesToExclude.add(cipherSuite);
+					}
+				}
+			}
+			sslContextFactory.setExcludeCipherSuites(cipherSuitesToExclude.toArray(new String[cipherSuitesToExclude.size()]));
+		}
+
+		// In light of attacks against SSL 3.0 as "POODLE" it is useful to include or exclude
+		// SSL/TLS protocols as needed.
+		if ( (null != protocolsIncluded) && (!protocolsIncluded.isEmpty()) ) {
+			sslContextFactory.setIncludeProtocols(protocolsIncluded.toArray(new String[protocolsIncluded.size()]));
+		}
+		if ( (null != protocolsExcluded) && (!protocolsExcluded.isEmpty()) ) {
+			sslContextFactory.setExcludeProtocols(protocolsExcluded.toArray(new String[protocolsExcluded.size()]));
 		}
 
 		if (useNIO) {

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ServerControllerImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ServerControllerImpl.java
@@ -513,11 +513,27 @@ class ServerControllerImpl implements ServerController {
 											address, configuration
 													.getSslKeystoreType(),
 											configuration
+													.getSslKeyAlias(),
+											configuration
+													.getTrustStore(),
+											configuration
+													.getTrustStorePassword(),
+											configuration
+													.getTrustStoreType(),
+											configuration
 													.isClientAuthNeeded(),
 											configuration
 													.isClientAuthWanted(),
 											configuration
-													.useNIO());
+													.useNIO(),
+											configuration
+													.getCiphersuiteIncluded(),
+											configuration
+													.getCiphersuiteExcluded(),
+											configuration
+													.getProtocolsIncluded(),
+											configuration
+													.getProtocolsExcluded());
 							if (httpSecureConnector == null) {
 								httpSecureConnector = secureConnector;
 							}

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/ConfigurationImpl.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/ConfigurationImpl.java
@@ -50,10 +50,18 @@ import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SESSION_T
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SESSION_URL;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_CLIENT_AUTH_NEEDED;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_CLIENT_AUTH_WANTED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEY_ALIAS;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEYPASSWORD;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEYSTORE;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEYSTORE_TYPE;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_PASSWORD;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_TRUST_STORE;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_TRUST_STORE_PASSWORD;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_TRUST_STORE_TYPE;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_CIPHERSUITES_INCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_CIPHERSUITES_EXCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_PROTOCOLS_INCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_PROTOCOLS_EXCLUDED;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_TEMP_DIR;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_VIRTUAL_HOST_LIST;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_WORKER_NAME;
@@ -62,6 +70,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -214,6 +223,90 @@ public class ConfigurationImpl extends PropertyStore implements Configuration {
 	@Override
 	public String getSslKeyPassword() {
 		return getResolvedStringProperty(PROPERTY_SSL_KEYPASSWORD);
+	}
+
+	/**
+	 * @see Configuration#getSslKeyPassword()
+	 */
+	@Override
+	public String getSslKeyAlias() {
+		return getResolvedStringProperty(PROPERTY_SSL_KEY_ALIAS);
+	}
+
+	/**
+	 * @see Configuration#getTrustStore()
+	 */
+	@Override
+	public String getTrustStore() {
+		return getResolvedStringProperty(PROPERTY_SSL_TRUST_STORE);
+	}
+
+	/**
+	 * @see Configuration#getTrustStorePassword()
+	 */
+	@Override
+	public String getTrustStorePassword() {
+		return getResolvedStringProperty(PROPERTY_SSL_TRUST_STORE_PASSWORD);
+	}
+
+	/**
+	 * @see Configuration#getTrustStoreType()
+	 */
+	@Override
+	public String getTrustStoreType() {
+		return getResolvedStringProperty(PROPERTY_SSL_TRUST_STORE_TYPE);
+	}
+
+	/**
+	 * @see Configuration#getCiphersuiteIncluded()
+	 */
+	@Override
+	public List<String> getCiphersuiteIncluded() {
+		String cipherIncludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITES_INCLUDED);
+		if (cipherIncludeString == null)
+			return Collections.emptyList();
+
+		final String[] split = cipherIncludeString.split(",");
+		return Arrays.asList(split);
+	}
+
+	/**
+	 * @see Configuration#getCiphersuiteExcluded()
+	 */
+	@Override
+	public List<String> getCiphersuiteExcluded() {
+		String cipherExcludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITES_EXCLUDED);
+		if (cipherExcludeString == null)
+			return Collections.emptyList();
+
+		final String[] split = cipherExcludeString.split(",");
+		return Arrays.asList(split);
+	}
+
+	/**
+	 * @see Configuration#getProtocolsIncluded()
+	 */
+	@Override
+	public List<String> getProtocolsIncluded() {
+		String protocolsIncludedString = getResolvedStringProperty(PROPERTY_PROTOCOLS_INCLUDED);
+		if (protocolsIncludedString == null)
+			return Collections.emptyList();
+
+		String[] split = protocolsIncludedString.split(",");
+		return Arrays.asList(split);
+	}
+
+	/**
+	 * @see Configuration#getProtocolsExcluded()
+	 */
+	@Override
+	public List<String> getProtocolsExcluded() {
+		String protocolsExcludedString = getResolvedStringProperty(PROPERTY_PROTOCOLS_EXCLUDED);
+		if (protocolsExcludedString == null)
+			return Collections.emptyList();
+
+		String[] split = protocolsExcludedString.split(",");
+		return Arrays.asList(split);
 	}
 
 	/**

--- a/pax-web-runtime/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/pax-web-runtime/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -24,6 +24,14 @@
 		<AD name="Keystore Type" id="org.ops4j.pax.web.ssl.keystore.type" type="String" default="" />
 		<AD name="Keystore Integrity Password" id="org.ops4j.pax.web.ssl.password" type="String" default="" />
 		<AD name="Keystore Password" id="org.ops4j.pax.web.ssl.keypassword" type="String" default="" />
+		<AD name="Keystore Private Key Entry Alias" id="org.ops4j.pax.web.ssl.key.alias" type="String" default="" />
+		<AD name="SSL Truststore" id="org.ops4j.pax.web.ssl.truststore" type="String" default="" />
+		<AD name="Truststore Password" id="org.ops4j.pax.web.ssl.truststore.password" type="String" default="" />
+		<AD name="Truststore Type" id="org.ops4j.pax.web.ssl.truststore.type" type="String" default="" />
+		<AD name="Included SSL/TLS Cipher Suites Regular Expressions" id="org.ops4j.pax.web.ssl.ciphersuites.included" type="String" default="" />
+		<AD name="Excluded SSL/TLS Cipher Suites Regular Expressions" id="org.ops4j.pax.web.ssl.ciphersuites.excluded" type="String" default="" />
+		<AD name="Included SSL/TLS Protocols" id="org.ops4j.pax.web.ssl.protocols.included" type="String" default="" />
+		<AD name="Excluded SSL/TLS Protocols" id="org.ops4j.pax.web.ssl.protocols.excluded" type="String" default="" />
 		<AD name="Client Authentication Wanted" id="org.ops4j.pax.web.ssl.clientauthwanted"	type="String" default="false" />
 		<AD name="Client Authentication Needed" id="org.ops4j.pax.web.ssl.clientauthneeded" type="String" default="false" />
 		<AD name="Configuration File for Jetty" id="org.ops4j.pax.web.config.file" type="String" default=""/>

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
@@ -82,6 +82,13 @@ public interface Configuration {
 	String getSslKeyPassword();
 
 	/**
+	 * Returns the alias of the ssl private key.
+	 * 
+	 * @return the alias of the ssl private key.
+	 */
+	String getSslKeyAlias();
+
+	/**
 	 * Returns the temporary directory, directory that will be set as
 	 * javax.servlet.context.tempdir.
 	 * 
@@ -184,4 +191,18 @@ public interface Configuration {
 	Boolean isLogNCSACookies();
 
 	Boolean isLogNCSAServer();
+
+	List<String> getCiphersuiteIncluded();
+
+	List<String> getCiphersuiteExcluded();
+
+	List<String> getProtocolsIncluded();
+
+	List<String> getProtocolsExcluded();
+
+	String getTrustStore();
+
+	String getTrustStorePassword();
+
+	String getTrustStoreType();
 }


### PR DESCRIPTION
I added support for the following:
1) Configuring an SSL/TLS private key alias because key stores often contain more than one private key entry. https://ops4j1.jira.com/browse/PAXWEB-919
2) Configuring an separate SSL/TLS truststore which is a common use case. https://ops4j1.jira.com/browse/PAXWEB-923
3) Configuring SSL/TLS included/excluded protocols. Because one might want to exclude SSLv3 or TLS 1.0 and TLS 1.1 explicitly for better security. https://ops4j1.jira.com/browse/PAXWEB-922
4) SSL/TLS included/excluded cipher suites. I wanted to back port this 3.2.x is the version that ships with karaf. 
5) I also noticed two issues with the implementation in the master branch for specifying included and excluded cipher suites A) cipher is spelled "cypher" and B) there is a missing "." before "ssl". So in the master branch PID + "ssl.cyphersuites.included" should be PID + ".ssl.ciphersuites.included". https://ops4j1.jira.com/browse/PAXWEB-920
6) Specifying included/excluded cipher suites is easier to do by specifying regexs. https://ops4j1.jira.com/browse/PAXWEB-921

I am submitting a pull request because I believe these to be worthwhile changes that the community would benefit from. If you like I can submit a pull request in master as well.

