### PR TITLE
Added support for configuring SSL/TLS private key alias, truststore, …

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
@@ -72,12 +72,24 @@ public interface WebContainerConstants {
 	String PROPERTY_SSL_KEYSTORE_TYPE = PID + ".ssl.keystore.type";
 	String PROPERTY_SSL_PASSWORD = PID + ".ssl.password";
 	String PROPERTY_SSL_KEYPASSWORD = PID + ".ssl.keypassword";
+	String PROPERTY_SSL_KEY_ALIAS = PID + ".ssl.key.alias";
+
+	String PROPERTY_SSL_TRUST_STORE = PID + ".ssl.truststore";
+	String PROPERTY_SSL_TRUST_STORE_PASSWORD = PID + ".ssl.truststore.password";
+	String PROPERTY_SSL_TRUST_STORE_TYPE = PID + ".ssl.truststore.type";
 
 	String PROPERTY_SSL_CLIENT_AUTH_WANTED = PID + ".ssl.clientauthwanted";
 	String PROPERTY_SSL_CLIENT_AUTH_NEEDED = PID + ".ssl.clientauthneeded";
 
+	@Deprecated
 	String PROPERTY_CIPHERSUITE_INCLUDED = PID + "ssl.cyphersuites.included";
+	@Deprecated
 	String PROPERTY_CIPHERSUITE_EXCLUDED = PID + "ssl.cyphersuites.excluded";
+
+	String PROPERTY_PROTOCOLS_INCLUDED = PID + ".ssl.protocols.included";
+	String PROPERTY_PROTOCOLS_EXCLUDED = PID + ".ssl.protocols.excluded";
+	String PROPERTY_CIPHERSUITES_INCLUDED = PID + ".ssl.ciphersuites.included";
+	String PROPERTY_CIPHERSUITES_EXCLUDED = PID + ".ssl.ciphersuites.excluded";
 
 	String PROPERTY_SESSION_TIMEOUT = PID + ".session.timeout";
 	String PROPERTY_SESSION_COOKIE = PID + ".session.cookie";

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/java/org/ops4j/pax/web/itest/undertow/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/java/org/ops4j/pax/web/itest/undertow/HttpServiceWithConfigAdminIntegrationTest.java
@@ -56,15 +56,17 @@ public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 		
 		String bundlePath = "mvn:org.ops4j.pax.web.samples/helloworld-hs/" + VersionUtil.getProjectVersion();
 		installWarBundle = installAndStartBundle(bundlePath);
-		
+		Thread.sleep(2000);
 		waitForServer("http://127.0.0.1:8181/");
+		Thread.sleep(2000);
 	}
 
 	@After
-	public void tearDown() throws BundleException {
+	public void tearDown() throws BundleException, InterruptedException {
 		if (installWarBundle != null) {
 			installWarBundle.stop();
 			installWarBundle.uninstall();
+			Thread.sleep(2000);
 		}
 	}
 

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactory.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactory.java
@@ -43,10 +43,18 @@ public interface JettyFactory {
 	 *            keystore password.
 	 * @param host
 	 *            the address on which the secure port should listen
-	 * @param cipherSuiteIncluded 
-	 * 			  a list of cipher suites to exclude
-	 * @param cipherSuiteExcluded 
-	 *            a list of cipher suites to include
+	 * @param sslKeystoreType
+	 *            the SSL/TLS key store type (e.g. jks, jceks, bks).
+	 * @param sslKeyAlias
+	 *            the alias of the server SSL/TLS private key entry in the key store.
+	 * @param cipherSuitesIncluded 
+	 *            a list of regular expressions used to match excluded cipher suites.
+	 * @param cipherSuitesExcluded 
+	 *            a list of regular expressions used to match included cipher suites.
+	 * @param protocolsIncluded
+	 *            list of SSL/TLS protocols that are acceptable.
+	 * @param protocolsExcluded
+	 *            list of SSL/TLS protocols that are not acceptable.
 	 * 
 	 * @return a secure connector
 	 * 
@@ -54,7 +62,10 @@ public interface JettyFactory {
 	 */
 	Connector createSecureConnector(Server server, String name, int port,
 			String sslKeystore, String sslPassword, String sslKeyPassword,
-			String host, String sslKeystoreType, boolean isClientAuthNeeded,
-			boolean isClientAuthWanted, List<String> cipherSuiteIncluded, List<String> cipherSuiteExcluded);
+			String host, String sslKeystoreType, String sslKeyAlias,
+			String trustStore, String trustStorePassword, String trustStoreType,
+			boolean isClientAuthNeeded, boolean isClientAuthWanted,
+			List<String> cipherSuitesIncluded, List<String> cipherSuitesExcluded,
+			List<String> protocolsIncluded, List<String> protocolsExcluded);
 
 }

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ServerControllerImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ServerControllerImpl.java
@@ -534,10 +534,22 @@ class ServerControllerImpl implements ServerController {
 											sslPassword, sslKeyPassword,
 											address, configuration
 													.getSslKeystoreType(),
+											configuration
+													.getSslKeyAlias(),
+											configuration
+													.getTrustStore(),
+											configuration
+													.getTrustStorePassword(),
+											configuration
+													.getTrustStoreType(),
 											configuration.isClientAuthNeeded(),
 											configuration.isClientAuthWanted(), 
 											configuration.getCiphersuiteIncluded(), 
-											configuration.getCiphersuiteExcluded());
+											configuration.getCiphersuiteExcluded(),
+											configuration
+													.getProtocolsIncluded(),
+											configuration
+													.getProtocolsExcluded());
 							if (httpSecureConnector == null) {
 								httpSecureConnector = (ServerConnector) secureConnector;
 							}

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/ConfigurationImpl.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/ConfigurationImpl.java
@@ -54,9 +54,17 @@ import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_CLIEN
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEYPASSWORD;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEYSTORE;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEYSTORE_TYPE;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_KEY_ALIAS;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_PASSWORD;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_TRUST_STORE;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_TRUST_STORE_PASSWORD;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_SSL_TRUST_STORE_TYPE;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_CIPHERSUITE_INCLUDED;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_CIPHERSUITE_EXCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_CIPHERSUITES_INCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_CIPHERSUITES_EXCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_PROTOCOLS_INCLUDED;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_PROTOCOLS_EXCLUDED;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_TEMP_DIR;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_VIRTUAL_HOST_LIST;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_WORKER_NAME;
@@ -223,23 +231,98 @@ public class ConfigurationImpl extends PropertyStore implements Configuration {
 		return getResolvedStringProperty(PROPERTY_SSL_KEYPASSWORD);
 	}
 
+	/**
+	 * @see Configuration#getSslKeyPassword()
+	 */
+	@Override
+	public String getSslKeyAlias() {
+		return getResolvedStringProperty(PROPERTY_SSL_KEY_ALIAS);
+	}
+
+	/**
+	 * @see Configuration#getTrustStore()
+	 */
+	@Override
+	public String getTrustStore() {
+		return getResolvedStringProperty(PROPERTY_SSL_TRUST_STORE);
+	}
+
+	/**
+	 * @see Configuration#getTrustStorePassword()
+	 */
+	@Override
+	public String getTrustStorePassword() {
+		return getResolvedStringProperty(PROPERTY_SSL_TRUST_STORE_PASSWORD);
+	}
+
+	/**
+	 * @see Configuration#getTrustStoreType()
+	 */
+	@Override
+	public String getTrustStoreType() {
+		return getResolvedStringProperty(PROPERTY_SSL_TRUST_STORE_TYPE);
+	}
+
+	/**
+	 * @see Configuration#getCiphersuiteIncluded()
+	 */
 	@Override
 	public List<String> getCiphersuiteIncluded() {
-		String cypherIncludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITE_INCLUDED);
-		if (cypherIncludeString == null)
+		String cipherIncludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITES_INCLUDED);
+		// Try the deprecated property.
+		if ((null == cipherIncludeString) || ("".equals(cipherIncludeString))) {
+			cipherIncludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITE_INCLUDED);
+		}
+		if (cipherIncludeString == null)
 			return Collections.emptyList();
-		String[] split = cypherIncludeString.split(",");
+
+		final String[] split = cipherIncludeString.split(",");
 		return Arrays.asList(split);
 	}
-	
+
+	/**
+	 * @see Configuration#getCiphersuiteExcluded()
+	 */
 	@Override
 	public List<String> getCiphersuiteExcluded() {
-		String cypherExcludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITE_EXCLUDED);
-		if (cypherExcludeString == null)
+		String cipherExcludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITES_EXCLUDED);
+		// Try the deprecated property.
+		if ((null == cipherExcludeString) || ("".equals(cipherExcludeString))) {
+			cipherExcludeString = getResolvedStringProperty(PROPERTY_CIPHERSUITE_EXCLUDED);
+		}
+		if (cipherExcludeString == null)
 			return Collections.emptyList();
-		String[] split = cypherExcludeString.split(",");
+
+		final String[] split = cipherExcludeString.split(",");
 		return Arrays.asList(split);
 	}
+
+	/**
+	 * @see Configuration#getProtocolsIncluded()
+	 */
+	@Override
+	public List<String> getProtocolsIncluded() {
+		String protocolsIncludedString = getResolvedStringProperty(PROPERTY_PROTOCOLS_INCLUDED);
+		if (protocolsIncludedString == null)
+			return Collections.emptyList();
+
+		String[] split = protocolsIncludedString.split(",");
+		return Arrays.asList(split);
+	}
+
+	/**
+	 * @see Configuration#getProtocolsExcluded()
+	 */
+	@Override
+	public List<String> getProtocolsExcluded() {
+		String protocolsExcludedString = getResolvedStringProperty(PROPERTY_PROTOCOLS_EXCLUDED);
+		if (protocolsExcludedString == null)
+			return Collections.emptyList();
+
+		String[] split = protocolsExcludedString.split(",");
+		return Arrays.asList(split);
+	}
+
 	
 	/**
 	 * @see Configuration#getTemporaryDirectory()

--- a/pax-web-runtime/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/pax-web-runtime/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -25,10 +25,16 @@
 		<AD name="Keystore Type" id="org.ops4j.pax.web.ssl.keystore.type" type="String" default="" />
 		<AD name="Keystore Integrity Password" id="org.ops4j.pax.web.ssl.password" type="String" default="" />
 		<AD name="Keystore Password" id="org.ops4j.pax.web.ssl.keypassword" type="String" default="" />
+		<AD name="Keystore Private Key Entry Alias" id="org.ops4j.pax.web.ssl.key.alias" type="String" default="" />
+		<AD name="SSL Truststore" id="org.ops4j.pax.web.ssl.truststore" type="String" default="" />
+		<AD name="Truststore Password" id="org.ops4j.pax.web.ssl.truststore.password" type="String" default="" />
+		<AD name="Truststore Type" id="org.ops4j.pax.web.ssl.truststore.type" type="String" default="" />
 		<AD name="Client Authentication Wanted" id="org.ops4j.pax.web.ssl.clientauthwanted"	type="String" default="false" />
 		<AD name="Client Authentication Needed" id="org.ops4j.pax.web.ssl.clientauthneeded" type="String" default="false" />
-		<AD name="Cipther suite included" id="org.ops4j.pax.web.ssl.ciphersuites.included" type="String" default="" />
-		<AD name="Cipther suite excluded" id="org.ops4j.pax.web.ssl.ciphersuites.excluded" type="String" default="" />
+		<AD name="Included SSL/TLS Cipher Suites Regular Expressions" id="org.ops4j.pax.web.ssl.ciphersuites.included" type="String" default="" />
+		<AD name="Excluded SSL/TLS Cipher Suites Regular Expressions" id="org.ops4j.pax.web.ssl.ciphersuites.excluded" type="String" default="" />
+		<AD name="Included SSL/TLS Protocols" id="org.ops4j.pax.web.ssl.protocols.included" type="String" default="" />
+		<AD name="Excluded SSL/TLS Protocols" id="org.ops4j.pax.web.ssl.protocols.excluded" type="String" default="" />
 		<AD name="Configuration File for Jetty" id="org.ops4j.pax.web.config.file" type="String" default=""/>
 		<AD name="JSP scratchdir" id="org.ops4j.pax.web.jsp.scratch.dir" type="String" default="" />
 		<AD name="JSP checkInterval" id="org.ops4j.pax.web.jsp.check.interval" type="String" default="300" />

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
@@ -82,6 +82,13 @@ public interface Configuration {
 	String getSslKeyPassword();
 
 	/**
+	 * Returns the alias of the ssl private key.
+	 * 
+	 * @return the alias of the ssl private key.
+	 */
+	String getSslKeyAlias();
+
+	/**
 	 * Returns the temporary directory, directory that will be set as
 	 * javax.servlet.context.tempdir.
 	 * 
@@ -189,10 +196,19 @@ public interface Configuration {
 
 	List<String> getCiphersuiteExcluded();
 
+	List<String> getProtocolsIncluded();
+
+	List<String> getProtocolsExcluded();
+
 	Integer getServerMaxThreads();
 
 	Integer getServerMinThreads();
 
 	Integer getServerIdleTimeout();
 
+	String getTrustStore();
+
+	String getTrustStorePassword();
+
+	String getTrustStoreType();
 }


### PR DESCRIPTION
…included/excluded protocols, included/excluded cipher suites with regex. Fixed name and missing period in cipher suites properties.

I added support for the following:
1) Configuring an SSL/TLS private key alias because key stores often contain more than one private key entry. https://ops4j1.jira.com/browse/PAXWEB-919
2) Configuring an separate SSL/TLS truststore which is a common use case. https://ops4j1.jira.com/browse/PAXWEB-923
3) Configuring SSL/TLS included/excluded protocols. Because one might want to exclude SSLv3 or TLS 1.0 and TLS 1.1 explicitly for better security. https://ops4j1.jira.com/browse/PAXWEB-922
4) SSL/TLS included/excluded cipher suites. I wanted to back port this 3.2.x is the version that ships with karaf.
5) I also noticed two issues with the implementation in the master branch for specifying included and excluded cipher suites A) cipher is spelled "cypher" and B) there is a missing "." before "ssl". So in the master branch PID + "ssl.cyphersuites.included" should be PID + ".ssl.ciphersuites.included". https://ops4j1.jira.com/browse/PAXWEB-920
6) Specifying included/excluded cipher suites is easier to do by specifying regexs. https://ops4j1.jira.com/browse/PAXWEB-921