### PR TITLE
[PAXWEB-992] HttpService swallows Exceptions during startup

### DIFF
--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStarted.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStarted.java
@@ -1110,7 +1110,7 @@ class HttpServiceStarted implements StoppableHttpService {
 			if (e instanceof RuntimeException) {
 				throw (RuntimeException) e;
 			}
-			LOG.warn("Exception starting HttpContext registration");
+			LOG.error("Exception starting HttpContext registration", e);
 		}
 		//CHECKSTYLE:ON
 	}
@@ -1126,7 +1126,7 @@ class HttpServiceStarted implements StoppableHttpService {
 			if (e instanceof RuntimeException) {
 				throw (RuntimeException) e;
 			}
-			LOG.warn("Exception finalizing HttpContext registration");
+			LOG.error("Exception finalizing HttpContext registration", e);
 		}
 		//CHECKSTYLE:ON
 	}


### PR DESCRIPTION
Log exception as error, including cause