### PR TITLE
[PAXWEB-1007] Jetty Rewrite Handler cannot be used in jetty.xml

### DIFF
--- a/pax-web-features/src/main/resources/features.xml
+++ b/pax-web-features/src/main/resources/features.xml
@@ -20,6 +20,7 @@
         <bundle start-level="30">mvn:org.eclipse.jetty/jetty-webapp/${jetty.version}</bundle>
         <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jndi/${jetty.version}</bundle>
         <bundle start-level="30">mvn:org.eclipse.jetty/jetty-plus/${jetty.version}</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-rewrite/${jetty.version}</bundle>
 	</feature>
 
 	<feature name="http" version="${project.version}" resolver="(obr)">

--- a/pax-web-jetty/osgi.bnd
+++ b/pax-web-jetty/osgi.bnd
@@ -17,6 +17,7 @@ Import-Package:\
   org.eclipse.jetty.*; version="[7.1.0,8.0.0)",\
   org.eclipse.jetty.plus.jaas; version="[7.1.0,8.0.0)"; resolution:=optional,\
   org.eclipse.jetty.jmx; version="[7.1.0,8.0.0)"; resolution:=optional,\
+  org.eclipse.jetty.rewrite.handler; version="[7.1.0,8.0.0)"; resolution:=optional,\
   org.osgi.framework; version="[1.0.0,2.0.0)",\
   org.osgi.service.http; version="[1.0.0,2.0.0)",\
   org.slf4j; version="[1.5,2)"


### PR DESCRIPTION
UPDATED: https://ops4j1.jira.com/browse/PAXWEB-1007