### PR TITLE
[PAXWEB-954] Disable Classpath scanning for ContainerInitializers for servlet version < 3

### DIFF
--- a/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/support/TestServlet.java
+++ b/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/support/TestServlet.java
@@ -39,6 +39,7 @@ public class TestServlet extends HttpServlet {
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		resp.setContentType("text");
 		resp.getWriter().println("SimpleServlet: TEST OK");
 	}
 }

--- a/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/support/TestServletContainerInitializer.java
+++ b/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/support/TestServletContainerInitializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.base.support;
+
+
+import javax.servlet.*;
+import java.util.Set;
+
+/**
+ * Registers an additional Filter.
+ */
+public class TestServletContainerInitializer implements ServletContainerInitializer {
+    @Override
+    public void onStartup(Set<Class<?>> c, ServletContext servletContext) throws ServletException {
+        servletContext.addFilter("initializerFilter", SimpleFilter.class).addMappingForUrlPatterns(null, false, "/*");
+    }
+
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/WarContainerInitializerIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/WarContainerInitializerIntegrationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.jetty;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.tinybundles.core.InnerClassStrategy;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.TestServlet;
+import org.ops4j.pax.web.itest.base.support.TestServletContainerInitializer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import java.io.InputStream;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+
+/**
+ * @author Marc Schlegel
+ */
+@RunWith(PaxExam.class)
+public class WarContainerInitializerIntegrationTest extends ITestBase {
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(configureJetty(),
+				mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").version(asInProject()),
+				mavenBundle().groupId("biz.aQute.bnd").artifactId("bndlib").version(asInProject())
+		);
+	}
+
+	private Bundle installWarBundle(String webXml) throws Exception {
+			InputStream in = bundle()
+					.add(TestServlet.class, InnerClassStrategy.NONE)
+					.add(TestServletContainerInitializer.class, InnerClassStrategy.NONE)
+					.add("WEB-INF/web.xml",
+							WarContainerInitializerIntegrationTest.class.getClassLoader().getResourceAsStream(webXml))
+					.add("META-INF/services/javax.servlet.ServletContainerInitializer",
+							WarContainerInitializerIntegrationTest.class.getClassLoader().getResourceAsStream("META-INF/services/javax.servlet.ServletContainerInitializer"))
+					.set(Constants.BUNDLE_SYMBOLICNAME, "war-bundle")
+					.set(Constants.IMPORT_PACKAGE, "javax.servlet, javax.servlet.annotation, javax.servlet.http, org.ops4j.pax.web.itest.base.support")
+					.set(Constants.EXPORT_PACKAGE, "org.ops4j.pax.web.itest.jetty")
+					.set("Web-ContextPath", "contextroot")
+					.build();
+			return bundleContext.installBundle("bundleLocation", in);
+	}
+
+
+	@Test
+	public void testServlet_2_5() throws Exception {
+		initWebListener();
+		Bundle bundle = installWarBundle("web-2.5.xml");
+		bundle.start();
+
+		waitForWebListener();
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'TEST OK'!", resp -> resp.contains("TEST OK"))
+				.withResponseAssertion("Response must NOT contain 'FILTER-INIT'! Since this WAR uses Servlet 2.5 no ContainerInitializer should be used", resp -> !resp.contains("FILTER-INIT"))
+				.doGETandExecuteTest("http://127.0.0.1:8181/contextroot/servlet");
+
+		bundle.uninstall();
+	}
+
+
+	@Test
+	public void testServlet_3_0() throws Exception {
+		initWebListener();
+
+		Bundle bundle = installWarBundle("web-3.0.xml");
+		bundle.start();
+
+		waitForWebListener();
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'TEST OK'!", resp -> resp.contains("TEST OK"))
+				.withResponseAssertion("Filter is registered in Service-Locator for ContainerInitializer. Response must contain 'FILTER-INIT'", resp -> resp.contains("FILTER-INIT"))
+				.doGETandExecuteTest("http://127.0.0.1:8181/contextroot/servlet");
+
+		bundle.uninstall();
+	}
+}
+

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.ops4j.pax.web.itest.base.support.TestServletContainerInitializer

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/resources/web-2.5.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/resources/web-2.5.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+    <servlet>
+        <servlet-name>simple</servlet-name>
+        <servlet-class>org.ops4j.pax.web.itest.base.support.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>simple</servlet-name>
+        <url-pattern>servlet</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/resources/web-3.0.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/resources/web-3.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <servlet>
+        <servlet-name>simple</servlet-name>
+        <servlet-class>org.ops4j.pax.web.itest.base.support.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>simple</servlet-name>
+        <url-pattern>servlet</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/ITestBase.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/ITestBase.java
@@ -34,7 +34,7 @@ public class ITestBase extends AbstractTestBase {
 	@Inject
 	protected BundleContext bundleContext;
 
-	public Option[] configureBaseWithServlet() {
+	public static Option[] configureBaseWithServlet() {
 		return combine(
 				baseConfigure(),
 				systemProperty("org.osgi.service.http.port").value("8282"),
@@ -47,7 +47,7 @@ public class ITestBase extends AbstractTestBase {
 	}
 
 
-	public Option[] configureTomcat() {
+	public static Option[] configureTomcat() {
 		return combine(
 				configureBaseWithServlet(),
 				mavenBundle().groupId("org.ops4j.pax.web")

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarContainerInitializerIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarContainerInitializerIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.tinybundles.core.InnerClassStrategy;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.TestServlet;
+import org.ops4j.pax.web.itest.base.support.TestServletContainerInitializer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import java.io.InputStream;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+/**
+ * @author Marc Schlegel
+ */
+@RunWith(PaxExam.class)
+public class WarContainerInitializerIntegrationTest extends ITestBase {
+
+    @Configuration
+    public static Option[] configure() {
+        return combine(configureTomcat(),
+                mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").version(asInProject()),
+                mavenBundle().groupId("biz.aQute.bnd").artifactId("bndlib").version(asInProject())
+        );
+    }
+
+    private Bundle installWarBundle(String webXml) throws Exception {
+        InputStream in = bundle()
+                .add(TestServlet.class, InnerClassStrategy.NONE)
+                .add(TestServletContainerInitializer.class, InnerClassStrategy.NONE)
+                .add("WEB-INF/web.xml",
+                        WarContainerInitializerIntegrationTest.class.getClassLoader().getResourceAsStream(webXml))
+                .add("META-INF/services/javax.servlet.ServletContainerInitializer",
+                        WarContainerInitializerIntegrationTest.class.getClassLoader().getResourceAsStream("META-INF/services/javax.servlet.ServletContainerInitializer"))
+                .set(Constants.BUNDLE_SYMBOLICNAME, "war-bundle")
+                .set(Constants.IMPORT_PACKAGE, "javax.servlet, javax.servlet.annotation, javax.servlet.http, org.ops4j.pax.web.itest.base.support")
+                .set(Constants.EXPORT_PACKAGE, "org.ops4j.pax.web.itest.jetty")
+                .set("Web-ContextPath", "contextroot")
+                .build();
+        return bundleContext.installBundle("bundleLocation", in);
+    }
+
+
+    @Test
+    public void testServlet_2_5() throws Exception {
+        initWebListener();
+        Bundle bundle = installWarBundle("web-2.5.xml");
+        bundle.start();
+
+        waitForWebListener();
+
+        HttpTestClientFactory.createDefaultTestClient()
+                .withResponseAssertion("Response must contain 'TEST OK'!", resp -> resp.contains("TEST OK"))
+                .withResponseAssertion("Response must NOT contain 'FILTER-INIT'! Since this WAR uses Servlet 2.5 no ContainerInitializer should be used", resp -> !resp.contains("FILTER-INIT"))
+                .doGETandExecuteTest("http://127.0.0.1:8282/contextroot/servlet");
+
+        bundle.uninstall();
+    }
+
+
+    @Test
+    public void testServlet_3_0() throws Exception {
+        initWebListener();
+
+        Bundle bundle = installWarBundle("web-3.0.xml");
+        bundle.start();
+
+        waitForWebListener();
+
+        HttpTestClientFactory.createDefaultTestClient()
+                .withResponseAssertion("Response must contain 'TEST OK'!", resp -> resp.contains("TEST OK"))
+                .withResponseAssertion("Filter is registered in Service-Locator for ContainerInitializer. Response must contain 'FILTER-INIT'", resp -> resp.contains("FILTER-INIT"))
+                .doGETandExecuteTest("http://127.0.0.1:8282/contextroot/servlet");
+
+        bundle.uninstall();
+    }
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.ops4j.pax.web.itest.base.support.TestServletContainerInitializer

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/resources/web-2.5.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/resources/web-2.5.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+    <servlet>
+        <servlet-name>simple</servlet-name>
+        <servlet-class>org.ops4j.pax.web.itest.base.support.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>simple</servlet-name>
+        <url-pattern>servlet</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/resources/web-3.0.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/resources/web-3.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <servlet>
+        <servlet-name>simple</servlet-name>
+        <servlet-class>org.ops4j.pax.web.itest.base.support.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>simple</servlet-name>
+        <url-pattern>servlet</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/java/org/ops4j/pax/web/itest/undertow/WarContainerInitializerIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/java/org/ops4j/pax/web/itest/undertow/WarContainerInitializerIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.undertow;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.tinybundles.core.InnerClassStrategy;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.TestServlet;
+import org.ops4j.pax.web.itest.base.support.TestServletContainerInitializer;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import java.io.InputStream;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+/**
+ * @author Marc Schlegel
+ */
+@RunWith(PaxExam.class)
+public class WarContainerInitializerIntegrationTest extends ITestBase {
+
+    @Configuration
+    public static Option[] configure() {
+        return combine(configureUndertow(),
+                mavenBundle().groupId("org.ops4j.pax.tinybundles").artifactId("tinybundles").version(asInProject()),
+                mavenBundle().groupId("biz.aQute.bnd").artifactId("bndlib").version(asInProject())
+        );
+    }
+
+    private Bundle installWarBundle(String webXml) throws Exception {
+        InputStream in = bundle()
+                .add(TestServlet.class, InnerClassStrategy.NONE)
+                .add(TestServletContainerInitializer.class, InnerClassStrategy.NONE)
+                .add("WEB-INF/web.xml",
+                        WarContainerInitializerIntegrationTest.class.getClassLoader().getResourceAsStream(webXml))
+                .add("META-INF/services/javax.servlet.ServletContainerInitializer",
+                        WarContainerInitializerIntegrationTest.class.getClassLoader().getResourceAsStream("META-INF/services/javax.servlet.ServletContainerInitializer"))
+                .set(Constants.BUNDLE_SYMBOLICNAME, "war-bundle")
+                .set(Constants.IMPORT_PACKAGE, "javax.servlet, javax.servlet.annotation, javax.servlet.http, org.ops4j.pax.web.itest.base.support")
+                .set(Constants.EXPORT_PACKAGE, "org.ops4j.pax.web.itest.jetty")
+                .set("Web-ContextPath", "contextroot")
+                .build();
+        return bundleContext.installBundle("bundleLocation", in);
+    }
+
+
+    @Test
+    public void testServlet_2_5() throws Exception {
+        initWebListener();
+        Bundle bundle = installWarBundle("web-2.5.xml");
+        bundle.start();
+
+        waitForWebListener();
+
+        HttpTestClientFactory.createDefaultTestClient()
+                .withResponseAssertion("Response must contain 'TEST OK'!", resp -> resp.contains("TEST OK"))
+                .withResponseAssertion("Response must NOT contain 'FILTER-INIT'! Since this WAR uses Servlet 2.5 no ContainerInitializer should be used", resp -> !resp.contains("FILTER-INIT"))
+                .doGETandExecuteTest("http://127.0.0.1:8181/contextroot/servlet");
+
+        bundle.uninstall();
+    }
+
+
+    @Test
+    public void testServlet_3_0() throws Exception {
+        initWebListener();
+
+        Bundle bundle = installWarBundle("web-3.0.xml");
+        bundle.start();
+
+        waitForWebListener();
+
+        HttpTestClientFactory.createDefaultTestClient()
+                .withResponseAssertion("Response must contain 'TEST OK'!", resp -> resp.contains("TEST OK"))
+                .withResponseAssertion("Filter is registered in Service-Locator for ContainerInitializer. Response must contain 'FILTER-INIT'!", resp -> resp.contains("FILTER-INIT"))
+                .doGETandExecuteTest("http://127.0.0.1:8181/contextroot/servlet");
+
+        bundle.uninstall();
+    }
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.ops4j.pax.web.itest.base.support.TestServletContainerInitializer

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/resources/web-2.5.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/resources/web-2.5.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+    <servlet>
+        <servlet-name>simple</servlet-name>
+        <servlet-class>org.ops4j.pax.web.itest.base.support.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>simple</servlet-name>
+        <url-pattern>servlet</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/resources/web-3.0.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/resources/web-3.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
+
+    <servlet>
+        <servlet-name>simple</servlet-name>
+        <servlet-class>org.ops4j.pax.web.itest.base.support.TestServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>simple</servlet-name>
+        <url-pattern>servlet</url-pattern>
+    </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
- Moved scanning-logik
- Bundle-Classloader adapted by BundleWiring
- Fix accompanied with test using tinybundles instead dedicated sample-project.
- Fixed minor warnings