### PR TITLE
PAXWEB-1024 Register ServletContext as OSGi-service in all containers

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
@@ -185,6 +185,7 @@ public interface WebContainerConstants {
 	String PROPERTY_ENC_SUFFIX = PID + ".enc.suffix";
 
 	String PROPERTY_SERVLETCONTEXT_PATH = "osgi.web.contextpath";
+	String PROPERTY_SERVLETCONTEXT_NAME = "osgi.web.contextname";
 	String PROPERTY_SYMBOLIC_NAME = "osgi.web.symbolicname";
 }
 //CHECKSTYLE:ON

--- a/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerContext.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerContext.java
@@ -41,4 +41,9 @@ public interface WebContainerContext extends HttpContext {
 	 */
 	Set<String> getResourcePaths(String name);
 
+	/**
+	 * Returns the name of this Context.
+	 * @return name of the Context
+	 */
+	String getContextId();
 }

--- a/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/WebAppHttpContext.java
+++ b/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/WebAppHttpContext.java
@@ -70,7 +70,7 @@ class WebAppHttpContext implements HttpContext {
 	/**
 	 * The http context to delegate to.
 	 */
-	private final HttpContext httpContext;
+	protected final HttpContext httpContext;
 	/**
 	 * Mime mappings.
 	 */

--- a/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/WebAppWebContainerContext.java
+++ b/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/WebAppWebContainerContext.java
@@ -70,4 +70,12 @@ class WebAppWebContainerContext extends WebAppHttpContext implements
 		return foundPaths;
 	}
 
+	@Override
+	public String getContextId() {
+		if(httpContext instanceof WebContainerContext){
+			return ((WebContainerContext) httpContext).getContextId();
+		}
+		return null;
+	}
+
 }

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/HttpServiceContext.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/HttpServiceContext.java
@@ -122,7 +122,7 @@ class HttpServiceContext extends ServletContextHandler {
 		this.attributes = attributes;
 		this.httpContext = httpContext;
 		this.accessControllerContext = accessControllerContext;
-		setDisplayName(httpContext.toString());
+		setDisplayName(httpContext instanceof WebContainerContext ? ((WebContainerContext) httpContext).getContextId() : contextName);
 		this.servletContainerInitializers = containerInitializers != null ? containerInitializers
 				: new HashMap<>();
 		this.virtualHosts = new ArrayList<>(virtualHosts);
@@ -455,6 +455,7 @@ class HttpServiceContext extends ServletContextHandler {
 			webContextPath = "/";
 		}
 		properties.put(WebContainerConstants.PROPERTY_SERVLETCONTEXT_PATH, webContextPath);
+		properties.put(WebContainerConstants.PROPERTY_SERVLETCONTEXT_NAME, getServletContext().getServletContextName());
 
 		registerService(bundleContext, properties);
 		LOG.debug("ServletContext registered as service. ");

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/DefaultHttpContext.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/DefaultHttpContext.java
@@ -116,6 +116,11 @@ class DefaultHttpContext implements WebContainerContext {
 	}
 
 	@Override
+	public String getContextId() {
+		return contextID;
+	}
+
+	@Override
 	public String toString() {
 		return "DefaultHttpContext [bundle=" + bundle + ", contextID="
 				+ contextID + "]";

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/DefaultSharedWebContainerContext.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/DefaultSharedWebContainerContext.java
@@ -39,6 +39,7 @@ public class DefaultSharedWebContainerContext implements
 			.getLogger(DefaultSharedWebContainerContext.class);
 
 	private Queue<Bundle> bundles = new ConcurrentLinkedQueue<>();
+	private String contextId = "shared";
 
 	@Override
 	public boolean registerBundle(Bundle bundle) {
@@ -63,6 +64,11 @@ public class DefaultSharedWebContainerContext implements
 			}
 		}
 		return null;
+	}
+
+	@Override
+	public String getContextId() {
+		return contextId;
 	}
 
 	@Override

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -76,6 +76,7 @@ import org.ops4j.lang.NullArgumentException;
 import org.ops4j.pax.swissbox.core.BundleUtils;
 import org.ops4j.pax.swissbox.core.ContextClassLoaderUtils;
 import org.ops4j.pax.web.service.WebContainerConstants;
+import org.ops4j.pax.web.service.WebContainerContext;
 import org.ops4j.pax.web.service.spi.LifeCycle;
 import org.ops4j.pax.web.service.spi.model.ContextModel;
 import org.ops4j.pax.web.service.spi.model.ErrorPageModel;
@@ -938,6 +939,7 @@ class TomcatServerWrapper implements ServerWrapper {
 		final Bundle bundle = contextModel.getBundle();
 		final BundleContext bundleContext = BundleUtils
 				.getBundleContext(bundle);
+		final HttpContext httpContext = contextModel.getHttpContext();
 
 		final Context context = server.addContext(
 				contextModel.getContextParams(),
@@ -949,6 +951,7 @@ class TomcatServerWrapper implements ServerWrapper {
 				contextModel.getVirtualHosts(), null /*contextModel.getConnectors() */,
 				server.getBasedir());
 
+		context.setDisplayName(httpContext instanceof WebContainerContext ? ((WebContainerContext) httpContext).getContextId() : contextModel.getContextName());
 		context.setParentClassLoader(contextModel.getClassLoader());
 		// TODO: is the context already configured?
 		// TODO: how about security, classloader?
@@ -996,6 +999,7 @@ class TomcatServerWrapper implements ServerWrapper {
 			}
 
 			properties.put(WebContainerConstants.PROPERTY_SERVLETCONTEXT_PATH, webContextPath);
+			properties.put(WebContainerConstants.PROPERTY_SERVLETCONTEXT_NAME, context.getServletContext().getServletContextName());
 
 			servletContextService = bundleContext.registerService(
 					ServletContext.class, servletContext, properties);

--- a/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/Context.java
+++ b/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/Context.java
@@ -294,6 +294,7 @@ public class Context implements LifeCycle, HttpHandler, ResourceManager {
 				Dictionary<String, String> props = new Hashtable<>(2);
 				props.put(WebContainerConstants.PROPERTY_SYMBOLIC_NAME, bundle.getSymbolicName());
 				props.put(WebContainerConstants.PROPERTY_SERVLETCONTEXT_PATH, webContextPath);
+				props.put(WebContainerConstants.PROPERTY_SERVLETCONTEXT_NAME, servletContext.getServletContextName());
 				ServiceRegistration<ServletContext> serviceReg = bundle.getBundleContext().registerService(
 						ServletContext.class,
 						servletContext,
@@ -304,10 +305,11 @@ public class Context implements LifeCycle, HttpHandler, ResourceManager {
 	}
 
 	private void doCreateHandler() throws ServletException {
+		final HttpContext httpContext = contextModel.getHttpContext();
 		DeploymentInfo deployment = new DeploymentInfo();
 		deployment.setEagerFilterInit(true);
 		deployment.setDeploymentName(contextModel.getContextName());
-		deployment.setDisplayName(contextModel.getContextName());
+		deployment.setDisplayName(httpContext instanceof WebContainerContext ? ((WebContainerContext) httpContext).getContextId() : contextModel.getContextName());
 		deployment.setContextPath('/' + contextModel.getContextName());
 		deployment.setClassLoader(classLoader);
 		BundleContext bundleContext = contextModel.getBundle().getBundleContext();


### PR DESCRIPTION
In order to pass the ContextName (aka ContextId) down to the containers the interface WebContainerContext was enhanced.

This fix is also relevant for PAXWEB-906 where I currently have no way to match a registered ServletContext with the information available in the runtime.
