### PR TITLE
move xsi:schemaLocation before the comment

### DIFF
--- a/pax-web-archetypes/wab-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/pax-web-archetypes/wab-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 <!--
 
 	Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 	limitations under the License.
 
 -->
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
eclipse (verified on neon.2) won't create projects with this archetype (see below). 
---
Unable to create project from archetype [org.ops4j.pax.web.archetypes:wab-archetype:6.0.1]
org.codehaus.plexus.util.xml.pull.XmlPullParserException: start tag unexpected character < (position: START_DOCUMENT seen ...POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n<... @3:2)