### PR TITLE
[PAXWEB-630] Further improvements

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/TomcatSecureConfigurationIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/TomcatSecureConfigurationIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+/**
+ * @author Achim Nierbeck
+ */
+@RunWith(PaxExam.class)
+public class TomcatSecureConfigurationIntegrationTest extends ITestBase {
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public Option[] configure() {
+		return combine(
+				configureTomcat(),
+                systemProperty("org.osgi.service.http.secure.enabled").value("true"),
+                systemProperty("org.osgi.service.http.port.secure").value("8443"),
+				mavenBundle().groupId("org.ops4j.pax.web.samples")
+						.artifactId("tomcat-config-fragment")
+						.version(VersionUtil.getProjectVersion()).noStart());
+
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		logger.info("Setting up test");
+
+		initWebListener();
+
+		final String bundlePath = WEB_BUNDLE
+				+ "mvn:org.ops4j.pax.web.samples/war/" + VersionUtil.getProjectVersion()
+				+ "/war?" + WEB_CONTEXT_PATH + "=/test";
+		installWarBundle = bundleContext.installBundle(bundlePath);
+		installWarBundle.start();
+
+		waitForWebListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+	@Test
+	public void testWeb() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("https://localhost:8443/test/wc/example");
+	}
+
+	@Test
+	public void testWebIP() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("https://127.0.0.1:8443/test/wc/example");
+	}
+}

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/EmbeddedTomcat.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/EmbeddedTomcat.java
@@ -315,7 +315,6 @@ public class EmbeddedTomcat extends Tomcat {
                                     httpConnector = connector;
                                 }
                                 //CHECKSTYLE:ON
-                                configureConnector(configuration, null, httpPort, useNIO, connector);
                                 masterConnectorFound = true;
                                 LOG.debug("master connector found, will alter it");
                             } else {
@@ -365,7 +364,6 @@ public class EmbeddedTomcat extends Tomcat {
                             if (matches(address, httpSecurePort, connector)) {
                                 httpSecureConnector = sslCon;
                                 masterSSLConnectorFound = true;
-                                configureSSLConnector(configuration, null, useNIO, httpSecurePort, sslCon);
                             } else {
                                 // default behaviour
                                 if (backupConnector == null) {

--- a/samples/tomcat-config-fragment/pom.xml
+++ b/samples/tomcat-config-fragment/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>tomcat-config-fragment</artifactId>
   <packaging>bundle</packaging>
 
-  <name>OPS4J Pax Web - Samples - Jetty config fragment</name>
+  <name>OPS4J Pax Web - Samples - Tomcat config fragment</name>
 
   <properties>
     <bundle.symbolicName>org.ops4j.pax.web.samples.tomcat.config</bundle.symbolicName>

--- a/samples/tomcat-config-fragment/src/main/resources/tomcat-server.xml
+++ b/samples/tomcat-config-fragment/src/main/resources/tomcat-server.xml
@@ -20,7 +20,11 @@
 
     <Connector port="8282" protocol="HTTP/1.1" redirectPort="8443" />
     <Connector port="8283" address="127.0.0.1" protocol="HTTP/1.1" redirectPort="8443" />
- 
+
+    <Connector port="8443" protocol="HTTP/1.1" scheme="https" secure="true" SSLEnabled="true"
+               keystoreFile="../src/test/resources-binary/keystore" keystorePass="password"
+               clientAuth="false" sslProtocol="TLS"/>
+
     <Engine name="Catalina" defaultHost="localhost">
  
       <Host name="localhost"  appBase="webapps"


### PR DESCRIPTION
- don't reconfigure connectors configured in tomcat-server.xml. This is also not done for Jetty
- add a test using a HTTPS connector configured in the tomcat-server.xml
- fix some checkstyle warnings in the newly introduced code