### PR TITLE
[PAXWEB-993] Fix JSF-Support for Tomcat and enable Tests

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFTCIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFTCIntegrationTest.java
@@ -17,7 +17,6 @@ package org.ops4j.pax.web.itest.tomcat;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -35,14 +34,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.fail;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.MavenUtils.asInProject;
 
 /**
  * @author Achim Nierbeck
  */
 @RunWith(PaxExam.class)
-@Ignore("Failes: can't find the EL factory -> [PAXWEB-929] should fix this")
 public class WarJSFTCIntegrationTest extends ITestBase {
 
 	private Bundle installWarBundle;
@@ -96,7 +92,7 @@ public class WarJSFTCIntegrationTest extends ITestBase {
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain 'Please enter your name'",
 						resp -> resp.contains("Please enter your name"))
-				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample/");
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample/index.jsp");
 	}
 
 	@Test
@@ -128,7 +124,7 @@ public class WarJSFTCIntegrationTest extends ITestBase {
 							logger.debug("Found ID: {}", inputID);
 							return true;
 						})
-				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample");
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample/index.jsp");
 
 		Pattern patternViewState = Pattern
 				.compile("id=\\\"j_id_.*:javax.faces.ViewState:\\w\\\"");
@@ -156,7 +152,7 @@ public class WarJSFTCIntegrationTest extends ITestBase {
 				.useCookieState(cookieState)
 				.withResponseAssertion("Response from POST must contain 'Hello Dummy-User. We hope you enjoy Apache MyFaces'",
 						resp -> resp.contains("Hello Dummy-User. We hope you enjoy Apache MyFaces"))
-				.doPOST("http://127.0.0.1:8181/war-jsf-sample/faces/helloWorld.jsp")
+				.doPOST("http://127.0.0.1:8282/war-jsf-sample/faces/helloWorld.jsp")
 				.addParameter("mainForm:name", "Dummy-User")
 				.addParameter(viewStateID, viewStateValue)
 				.addParameter(inputID, "Press me")

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJsfResourcehandlerIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJsfResourcehandlerIntegrationTest.java
@@ -21,12 +21,13 @@
 package org.ops4j.pax.web.itest.tomcat;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
 import org.ops4j.pax.web.itest.base.TestConfiguration;
 import org.ops4j.pax.web.itest.base.WaitCondition2;
 import org.ops4j.pax.web.itest.base.assertion.BundleMatchers;
@@ -56,7 +57,6 @@ import java.util.Collection;
 
 import static org.junit.Assert.fail;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.OptionUtils.combine;
 import static org.ops4j.pax.web.itest.base.assertion.Assert.assertThat;
 
@@ -64,6 +64,9 @@ import static org.ops4j.pax.web.itest.base.assertion.Assert.assertThat;
  * @author Marc Schlegel
  */
 @RunWith(PaxExam.class)
+// testResourceUnavailable uninstalls a bundle, so it destroys the container for 
+// other tests. Therefore we need a new container per test method
+@ExamReactorStrategy(PerMethod.class)
 public class WarJsfResourcehandlerIntegrationTest extends ITestBase {
 
 	@Configuration
@@ -146,7 +149,6 @@ public class WarJsfResourcehandlerIntegrationTest extends ITestBase {
 	 * </pre>
 	 */
 	@Test
-	@Ignore("[PAXWEB-929] should fix this")
 	public void testJsfResourceHandler() throws Exception {
 		final String pageUrl = "http://127.0.0.1:8282/osgi-resourcehandler-myfaces/index.xhtml";
 		final String imageUrl = "http://127.0.0.1:8282/osgi-resourcehandler-myfaces/javax.faces.resource/images/iceland.jpg.xhtml?type=osgi&ln=default&lv=2_0";

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarTCIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarTCIntegrationTest.java
@@ -148,7 +148,7 @@ public class WarTCIntegrationTest extends ITestBase {
 
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
-						resp -> resp.contains("<h1>Hello World!</h1>"))
+						resp -> resp.contains("<h1>Hello World</h1>"))
 				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc");
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain '<h2>Hello World!</h2>'",

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -82,7 +82,11 @@
 							org.osgi.service.http; version="[1.0.0,2.0.0)",
 							org.slf4j; version="[1.5,2)",
 							javax.el; version="[2.1.0,3.1.0)";resolution:=optional,
-							org.apache.el.*; version="2.2",
+							org.apache.el; version="2.2"; resolution:=optional,
+							org.apache.el.lang; version="2.2"; resolution:=optional,
+							org.apache.el.parser; version="2.2"; resolution:=optional,
+							org.apache.el.stream; version="2.2"; resolution:=optional,
+							org.apache.el.util; version="2.2"; resolution:=optional
 							org.apache.catalina,
 							org.apache.catalina.authenticator,
 							org.apache.catalina.comet,

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.DispatcherType;
@@ -73,8 +72,8 @@ import org.apache.tomcat.util.descriptor.web.SecurityCollection;
 import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
 import org.apache.tomcat.util.descriptor.web.TaglibDescriptorImpl;
 import org.ops4j.lang.NullArgumentException;
+import org.ops4j.pax.swissbox.core.BundleClassLoader;
 import org.ops4j.pax.swissbox.core.BundleUtils;
-import org.ops4j.pax.swissbox.core.ContextClassLoaderUtils;
 import org.ops4j.pax.web.service.WebContainerConstants;
 import org.ops4j.pax.web.service.WebContainerContext;
 import org.ops4j.pax.web.service.spi.LifeCycle;
@@ -86,6 +85,7 @@ import org.ops4j.pax.web.service.spi.model.Model;
 import org.ops4j.pax.web.service.spi.model.SecurityConstraintMappingModel;
 import org.ops4j.pax.web.service.spi.model.ServletModel;
 import org.ops4j.pax.web.service.spi.model.WelcomeFileModel;
+import org.ops4j.pax.web.service.spi.util.ResourceDelegatingBundleClassLoader;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -271,23 +271,7 @@ class TomcatServerWrapper implements ServerWrapper {
 		@Override
 		public synchronized void load() throws ServletException {
 			try {
-				instance = ContextClassLoaderUtils.doWithClassLoader(
-						model.getContextModel().getClassLoader(),
-						new Callable<Servlet>() {
-
-							@Override
-							public Servlet call() {
-								try {
-									return loadServlet();
-								} catch (final ServletException e) {
-									LOG.warn(
-											"Caucht exception while loading Servlet with classloader {}",
-											e);
-									return null;
-								}
-							}
-
-						});
+				instance =  loadServlet();
 			} catch (Exception e) {
 				if (e instanceof RuntimeException) {
 					throw (RuntimeException) e;
@@ -876,18 +860,7 @@ class TomcatServerWrapper implements ServerWrapper {
 				if (!context.getState().isAvailable()) {
 					LOG.info("server is available, in state {}",
 							context.getState());
-
-					ContextClassLoaderUtils.doWithClassLoader(
-							context.getParentClassLoader(),
-							new Callable<Void>() {
-
-								@Override
-								public Void call() throws LifecycleException {
-									context.start();
-									return null;
-								}
-
-							});
+					context.start();
 				}
 			}
 
@@ -952,7 +925,13 @@ class TomcatServerWrapper implements ServerWrapper {
 				server.getBasedir());
 
 		context.setDisplayName(httpContext.getContextId());
-		context.setParentClassLoader(contextModel.getClassLoader());
+		// Similar to the Jetty fix for PAXWEB-725
+		// Without this the el implementation is not found
+        ClassLoader classLoader = contextModel.getClassLoader();
+        List<Bundle> bundles = ((ResourceDelegatingBundleClassLoader) classLoader).getBundles();
+        ClassLoader parentClassLoader = getClass().getClassLoader();
+        ResourceDelegatingBundleClassLoader containerSpecificClassLoader = new ResourceDelegatingBundleClassLoader(bundles, parentClassLoader);
+        context.setParentClassLoader(containerSpecificClassLoader);
 		// TODO: is the context already configured?
 		// TODO: how about security, classloader?
 		// TODO: compare with JettyServerWrapper.addContext


### PR DESCRIPTION
This pull request does actually three things:
1. Enable el-support in tomcat. For that I had to change two things:
    a) The import statements for javax.el in the pom: I copied this from pax-web-jetty. The original statement does not work because with the *-logic bnd will introspect the classes in the bundle and generate imports for all referenced packaged. This does not work when the classes are referenced by reflection API.
    b) I created a new ResourceDelegatingBundleClassLoader with the pax-web-tomcat-bundle as parent, that I set as a parentClassloader to a context. pax-web-jetty does someting similar here, anf if I don't do it, the el Factory will not find an implementation.
2. Enable jfaces support in tomcat. The problem is that jfaces creates an internal HashMap for the factories and uses the thread context classloader as the key. If the classloader changes, jfaces will not find its factories, and the servlet will not initialize (and therefore not work). The existing coding changes to different thread context class loaders when loading the servlet and starting the contect (though I could not find out why). After I removed that classloader change the JSF bundles would work and it did not break any tests (and I could not find any oder adverse effect).
3. Re-Enable some ignored integration tests using JSF.