### PR TITLE
[PAXWEB-1072] welcome-files support for tomcat

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFTCIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFTCIntegrationTest.java
@@ -92,7 +92,7 @@ public class WarJSFTCIntegrationTest extends ITestBase {
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain 'Please enter your name'",
 						resp -> resp.contains("Please enter your name"))
-				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample/index.jsp");
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample");
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class WarJSFTCIntegrationTest extends ITestBase {
 							logger.debug("Found ID: {}", inputID);
 							return true;
 						})
-				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample/index.jsp");
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-sample");
 
 		Pattern patternViewState = Pattern
 				.compile("id=\\\"j_id_.*:javax.faces.ViewState:\\w\\\"");

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardTCIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardTCIntegrationTest.java
@@ -89,7 +89,6 @@ public class WhiteboardTCIntegrationTest extends ITestBase {
 	}
 
 	@Test
-	@Ignore("Failing for duplicate Context - PAXWEB-597")
 	public void testWhiteBoardSlash() throws Exception {
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain 'Welcome to the Welcome page'",

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatResourceServlet.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatResourceServlet.java
@@ -17,7 +17,9 @@ package org.ops4j.pax.web.service.tomcat.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.regex.Matcher;
 
 import javax.servlet.RequestDispatcher;
@@ -30,6 +32,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.catalina.Context;
 import org.apache.catalina.connector.ResponseFacade;
 import org.osgi.service.http.HttpContext;
 import org.slf4j.Logger;
@@ -45,6 +48,8 @@ public class TomcatResourceServlet extends HttpServlet {
 	 *
 	 */
 	private static final long serialVersionUID = 1L;
+
+	private static final int SECOND = 1000;
 
 	private static final Logger LOG = LoggerFactory
 			.getLogger(TomcatResourceServlet.class);
@@ -68,9 +73,12 @@ public class TomcatResourceServlet extends HttpServlet {
 	private final String contextName;
 	private final String alias;
 	private final String name;
+	private final Context context;
+	private String[] welcomes;
 
 	public TomcatResourceServlet(final HttpContext httpContext,
-								 final String contextName, final String alias, final String name) {
+								 final String contextName, final String alias, final String name,
+								 final Context context) {
 		this.httpContext = httpContext;
 		this.contextName = "/" + contextName;
 		this.alias = alias;
@@ -79,6 +87,15 @@ public class TomcatResourceServlet extends HttpServlet {
 		} else {
 			this.name = name;
 		}
+		this.context = context;
+	}
+
+	@Override
+	public void init() throws ServletException {
+	    welcomes = context.findWelcomeFiles();
+	    if (welcomes == null) {
+	        welcomes = new String[]{"index.html", "index.jsp"};
+	    }
 	}
 
 	@Override
@@ -90,15 +107,17 @@ public class TomcatResourceServlet extends HttpServlet {
 
 		String mapping = null;
 		Boolean included = request.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI) != null;
+		String pathInfo = null;
 		if (included) {
 			String servletPath = (String) request
 					.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
-			String pathInfo = (String) request
+			pathInfo = (String) request
 					.getAttribute(RequestDispatcher.INCLUDE_PATH_INFO);
 			if (servletPath == null) {
 				servletPath = request.getServletPath();
 				pathInfo = request.getPathInfo();
 			}
+			mapping = addPaths(servletPath, pathInfo);
 		} else {
 			included = Boolean.FALSE;
 			if (contextName.equals(alias)) {
@@ -114,10 +133,14 @@ public class TomcatResourceServlet extends HttpServlet {
 						.replaceFirst(contextName, "/");
 				if (!"default".equalsIgnoreCase(name)) {
 					mapping = mapping.replaceFirst(alias,
-							Matcher.quoteReplacement(name)); // TODO
+							Matcher.quoteReplacement(name));
 				}
+                pathInfo = ((HttpServletRequest) request).getPathInfo();
 			}
 		}
+
+	    boolean endsWithSlash = (mapping == null ? request.getServletPath()
+	                : mapping).endsWith("/");
 
 		final URL url = httpContext.getResource(mapping);
 
@@ -133,72 +156,200 @@ public class TomcatResourceServlet extends HttpServlet {
 			return;
 		}
 
-		// For Performanceimprovements turn caching on
-
+		URLConnection connection = null;
 		try {
-			// new Resource(url.openStream());
-			url.openStream();
-		} catch (IOException ioex) {
-			response.sendError(HttpServletResponse.SC_NOT_FOUND);
-			return;
-		}
-		// if the request contains an etag and its the same for the
-		// resource, we deliver a NOT MODIFIED response
-
-		// TODO: add lastModified, probably need to use the caching of the
-		// DefaultServlet ...
-		// set the etag
-		// response.setHeader(ETAG, eTag);
-		// String mimeType = m_httpContext.getMimeType(mapping);
-		String mimeType = getServletContext().getMimeType(url.getFile());
-		/*
-		 * No Fallback if (mimeType == null) { Buffer mimeTypeBuf =
-		 * mimeTypes.getMimeByExtension(mapping); mimeType = mimeTypeBuf != null
-		 * ? mimeTypeBuf.toString() : null; }
-		 */
-
-		if (mimeType == null) {
+			boolean foundResource;
 			try {
-				if (url.openConnection() != null) {
-					mimeType = url.openConnection().getContentType();
+				// new Resource(url.openStream());
+				connection = url.openConnection();
+				connection.connect();
+				foundResource = true;
+			} catch (IOException ioex) {
+				foundResource = false;
+			}
+
+			if (!foundResource && !endsWithSlash) {
+				if (!response.isCommitted()) {
+					response.sendError(HttpServletResponse.SC_NOT_FOUND);
 				}
-			} catch (IOException | NullPointerException ignore) {
-				// we do not care about such an exception as the fact that
-				// we are using also the connection for
-				// finding the mime type is just a "nice to have" not an
-				// requirement
-			}
-		}
-
-		if (mimeType == null) {
-			ServletContext servletContext = getServletConfig()
-					.getServletContext();
-			mimeType = servletContext.getMimeType(mapping);
-		}
-
-		if (mimeType != null) {
-			response.setContentType(mimeType);
-		}
-
-		ServletOutputStream out = response.getOutputStream();
-		if (out != null) { // null should be just in unit testing
-			ServletResponse r = response;
-			while (r instanceof ServletResponseWrapper) {
-				r = ((ServletResponseWrapper) r).getResponse();
-			}
-			if (r instanceof ResponseFacade) {
-				((ResponseFacade) r).getContentWritten();
-			}
-
-			IOException ioException = copyRange(url.openStream(), out);
-
-			if (ioException != null) {
-				response.sendError(HttpServletResponse.SC_NOT_FOUND);
 				return;
 			}
 
+			String welcome = getWelcomeFile(mapping);
+
+			// else look for a welcome file
+			if (null != welcome) {
+				LOG.debug("welcome={}", welcome);
+				// Forward to the index
+				RequestDispatcher dispatcher = request.getRequestDispatcher(welcome);
+				if (dispatcher != null) {
+					if (included.booleanValue()) {
+						dispatcher.include(request, response);
+						return;
+					} else {
+						dispatcher.forward(request, response);
+						return;
+					}
+				}
+			} else if (!foundResource) {
+				// still not found anything, then do the following ...
+				if (!response.isCommitted()) {
+					response.sendError(HttpServletResponse.SC_NOT_FOUND);
+				}
+				return;
+			}
+
+			// if the request contains an etag and its the same for the
+			// resource, we deliver a NOT MODIFIED response
+			String eTag = String.valueOf(connection.getLastModified());
+			if ((request.getHeader(IF_NONE_MATCH) != null) && (eTag.equals(request.getHeader(IF_NONE_MATCH)))) {
+				response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+				return;
+			} else if (request.getHeader(IF_MODIFIED_SINCE) != null) {
+				long ifModifiedSince = request.getDateHeader(IF_MODIFIED_SINCE);
+				if (connection.getLastModified() > 0) {
+					// resource.lastModified()/1000 <= ifmsl/1000
+					if (connection.getLastModified() / SECOND <= ifModifiedSince / SECOND) {
+						response.reset();
+						response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+						response.flushBuffer();
+						return;
+					}
+				}
+			} else if (request.getHeader(IF_UNMODIFIED_SINCE) != null) {
+				long modifiedSince = request.getDateHeader(IF_UNMODIFIED_SINCE);
+
+				if (modifiedSince != -1) {
+					if (connection.getLastModified() / SECOND > modifiedSince / SECOND) {
+						response.sendError(HttpServletResponse.SC_PRECONDITION_FAILED);
+						return;
+					}
+				}
+			}
+
+			// set the etag
+			response.setHeader(ETAG, eTag);
+
+			// String mimeType = m_httpContext.getMimeType(mapping);
+			String mimeType = getServletContext().getMimeType(url.getFile());
+			/*
+			 * No Fallback if (mimeType == null) { Buffer mimeTypeBuf =
+			 * mimeTypes.getMimeByExtension(mapping); mimeType = mimeTypeBuf !=
+			 * null ? mimeTypeBuf.toString() : null; }
+			 */
+
+			if (mimeType == null) {
+				try {
+					if (url.openConnection() != null) {
+						mimeType = url.openConnection().getContentType();
+					}
+				} catch (IOException | NullPointerException ignore) {
+					// we do not care about such an exception as the fact that
+					// we are using also the connection for
+					// finding the mime type is just a "nice to have" not an
+					// requirement
+				}
+			}
+
+			if (mimeType == null) {
+				ServletContext servletContext = getServletConfig().getServletContext();
+				mimeType = servletContext.getMimeType(mapping);
+			}
+
+			if (mimeType != null) {
+				response.setContentType(mimeType);
+			}
+
+			ServletOutputStream out = response.getOutputStream();
+			if (out != null) { // null should be just in unit testing
+				ServletResponse r = response;
+				while (r instanceof ServletResponseWrapper) {
+					r = ((ServletResponseWrapper) r).getResponse();
+				}
+				if (r instanceof ResponseFacade) {
+					((ResponseFacade) r).getContentWritten();
+				}
+
+				IOException ioException = copyRange(url.openStream(), out);
+
+				if (ioException != null) {
+					response.sendError(HttpServletResponse.SC_NOT_FOUND);
+				}
+			}
+		} finally {
+			if (connection != null) {
+				try {
+					connection.getInputStream().close();
+				} catch (IOException e) {
+					// ignore
+				}
+			}
+		}
+	}
+
+	/**
+	 * Finds a matching welcome file for the supplied {@link Resource}. This
+	 * will be the first entry in the list of configured {@link #_welcomes
+	 * welcome files} that existing within the directory referenced by the
+	 * <code>Resource</code>. If the resource is not a directory, or no matching
+	 * file is found, then it may look for a valid servlet mapping. If there is
+	 * none, then <code>null</code> is returned. The list of welcome files is
+	 * read from the {@link ContextHandler} for this servlet, or
+	 * <code>"index.jsp" , "index.html"</code> if that is <code>null</code>.
+	 *
+	 * @param resource
+	 * @return The path of the matching welcome file in context or null.
+	 * @throws IOException
+	 * @throws MalformedURLException
+	 */
+	private String getWelcomeFile(String pathInContext) throws MalformedURLException, IOException {
+
+		if (welcomes == null) {
+			return null;
 		}
 
+		String welcomeServlet = null;
+		for (int i = 0; i < welcomes.length; i++) {
+			String welcomeInContext = addPaths(pathInContext, welcomes[i]);
+			if (httpContext.getResource(welcomeInContext) != null) {
+				return welcomes[i];
+			}
+		}
+		return welcomeServlet;
+	}
+
+	private static String addPaths(String p1, String p2) {
+		if (p1 == null || p1.length() == 0) {
+			if (p1 != null && p2 == null)
+				return p1;
+			return p2;
+		}
+		if (p2 == null || p2.length() == 0)
+			return p1;
+		int split = p1.indexOf(';');
+		if (split < 0)
+			split = p1.indexOf('?');
+		if (split == 0)
+			return p2 + p1;
+		if (split < 0)
+			split = p1.length();
+		StringBuilder buf = new StringBuilder(p1.length() + p2.length() + 2);
+		buf.append(p1);
+		if (buf.charAt(split - 1) == '/') {
+			if (p2.startsWith("/")) {
+				buf.deleteCharAt(split - 1);
+				buf.insert(split - 1, p2);
+			} else
+				buf.insert(split, p2);
+		} else {
+			if (p2.startsWith("/"))
+				buf.insert(split, p2);
+			else {
+				buf.insert(split, '/');
+				buf.insert(split + 1, p2);
+			}
+		}
+		return buf.toString();
 	}
 
 	/**

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -794,8 +794,9 @@ class TomcatServerWrapper implements ServerWrapper {
 	public Servlet createResourceServlet(final ContextModel contextModel,
 										 final String alias, final String name) {
 		LOG.debug("createResourceServlet( contextModel: {}, alias: {}, name: {})");
+		final Context context = findOrCreateContext(contextModel);
 		return new TomcatResourceServlet(contextModel.getHttpContext(),
-				contextModel.getContextName(), alias, name);
+				contextModel.getContextName(), alias, name, context);
 	}
 
 	@Override


### PR DESCRIPTION
This change introduces welcome file support for tomcat. I adapted the coding from the (Jetty) ResourceServlet to the TomcatResourceServlet. I also copied the etag support (which was a to-do in tomcat and is directly adjectant to the welcome file support).

I could revert the uris for the WarJSFTCIntegrationTest back and enable another ignored integration test (that was testing the welcome file).