### PR TITLE
[PAXWEB-1075] Add integration tests for tomcat

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/CrossServiceIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/CrossServiceIntegrationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.extender.whiteboard.ExtenderConstants;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.SimpleFilter;
+import org.ops4j.pax.web.itest.base.support.TestServlet;
+import org.ops4j.pax.web.service.WebContainer;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.http.HttpContext;
+import org.osgi.service.http.HttpService;
+
+import javax.servlet.Filter;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+/**
+ * @author Toni Menzel (tonit)
+ * @since Mar 3, 2009
+ */
+@RunWith(PaxExam.class)
+public class CrossServiceIntegrationTest extends ITestBase {
+
+	@Configuration
+	public static Option[] configure() {
+		return configureTomcat();
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		initWebListener();
+		waitForWebListener();
+	}
+
+	@Test
+	@Ignore("Filter services do not work")
+	public void testMultipleServiceCombination() throws Exception {
+		ServiceReference<HttpService> reference = bundleContext.getServiceReference(HttpService.class);
+		HttpService httpService = bundleContext.getService(reference);
+
+		HttpContext defaultHttpContext = httpService.createDefaultHttpContext();
+
+		Dictionary<String, Object> contextProps = new Hashtable<>();
+		contextProps.put(ExtenderConstants.PROPERTY_HTTP_CONTEXT_ID, "crosservice");
+
+		bundleContext.registerService(HttpContext.class.getName(), defaultHttpContext, contextProps);
+
+		//registering without an explicit context might be the issue. 
+		httpService.registerServlet("/crosservice", new TestServlet(), null, defaultHttpContext);
+
+		// Register a servlet filter via whiteboard
+		Dictionary<String, Object> filterProps = new Hashtable<>();
+		filterProps.put("filter-name", "Sample Filter");
+		filterProps.put(ExtenderConstants.PROPERTY_URL_PATTERNS, "/crosservice/*");
+		filterProps.put(ExtenderConstants.PROPERTY_HTTP_CONTEXT_ID, "crosservice");
+		ServiceRegistration<?> registerService = bundleContext.registerService(Filter.class.getName(), new SimpleFilter(), filterProps);
+
+		try {
+			HttpTestClientFactory.createDefaultTestClient()
+					.withResponseAssertion("Crossservice response must contain 'TEST OK'", resp -> resp.contains("TEST OK"))
+					.withResponseAssertion("Crossservice response must contain 'FILTER-INIT: true'",
+							resp -> resp.contains("FILTER-INIT: true"))
+					.doGETandExecuteTest("http://127.0.0.1:8282/crosservice");
+
+		} finally {
+			registerService.unregister();
+
+			httpService.unregister("/crosservice");
+		}
+	}
+
+	@Test
+	@Ignore("Filter services do not work")
+	public void testMultipleServiceCombinationWithDefaultHttpContext() throws Exception {
+		ServiceReference<HttpService> reference = bundleContext.getServiceReference(HttpService.class);
+		HttpService httpService = bundleContext.getService(reference);
+
+		//registering without an explicit context might be the issue. 
+		httpService.registerServlet("/crosservice", new TestServlet(), null, null);
+
+		// Register a servlet filter via whiteboard
+		Dictionary<String, Object> filterProps = new Hashtable<>();
+//        filterProps.put("filter-name", "Sample Filter");
+		filterProps.put(ExtenderConstants.PROPERTY_URL_PATTERNS, "/crosservice/*");
+		ServiceRegistration<?> registerService = bundleContext.registerService(Filter.class.getName(), new SimpleFilter(), filterProps);
+		try {
+			HttpTestClientFactory.createDefaultTestClient()
+					.withResponseAssertion("Crossservice response must contain 'TEST OK'", resp -> resp.contains("TEST OK"))
+					.withResponseAssertion("Crossservice response must contain 'FILTER-INIT: true'",
+							resp -> resp.contains("FILTER-INIT: true"))
+					.doGETandExecuteTest("http://127.0.0.1:8282/crosservice");
+		} finally {
+			registerService.unregister();
+
+			httpService.unregister("/crosservice");
+		}
+	}
+
+	@Ignore("sharing the context for WABs isn't possible")
+	@Test
+	public void testMultipleServiceCombinationWithWebContainer() throws Exception {
+		ServiceReference<HttpService> reference = bundleContext.getServiceReference(HttpService.class);
+		HttpService httpService = bundleContext.getService(reference);
+
+		ServiceReference<WebContainer> wcReference = bundleContext.getServiceReference(WebContainer.class);
+		WebContainer wcService = bundleContext.getService(wcReference);
+
+
+		//registering without an explicit context might be the issue. 
+		httpService.registerServlet("/crosservice", new TestServlet(), null, null);
+
+		// Register a servlet filter via webcontainer
+		wcService.registerFilter(new SimpleFilter(), new String[]{"/crossservice/*"}, null, null, null);
+
+		try {
+			HttpTestClientFactory.createDefaultTestClient()
+					.withResponseAssertion("Crossservice response must contain 'TEST OK'", resp -> resp.contains("TEST OK"))
+					.withResponseAssertion("Crossservice response must contain 'FILTER-INIT: true'",
+							resp -> resp.contains("FILTER-INIT: true"))
+					.doGETandExecuteTest("http://127.0.0.1:8282/crosservice");
+		} finally {
+			wcService.unregisterFilter(new SimpleFilter());
+			httpService.unregister("/crosservice");
+		}
+	}
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpCustomContextIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpCustomContextIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+/**
+ * @author Toni Menzel (tonit)
+ * @since Mar 3, 2009
+ */
+@RunWith(PaxExam.class)
+public class HttpCustomContextIntegrationTest extends ITestBase {
+
+	private Bundle installBundle;
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(configureTomcat());
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		initServletListener();
+		String bundlePath = "mvn:org.ops4j.pax.web.samples/http-custom-context/"
+				+ VersionUtil.getProjectVersion();
+		installBundle = installAndStartBundle(bundlePath);
+		waitForServletListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installBundle != null) {
+			installBundle.stop();
+			installBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testRoot() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Session:'", resp -> resp.contains("Session:"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/");
+		// test image-serving
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/www/logo.png");
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.service.WebContainerConstants;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+
+/**
+ * @author Toni Menzel (tonit)
+ * @since Mar 3, 2009
+ */
+@RunWith(PaxExam.class)
+public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
+
+	private Bundle installWarBundle;
+
+	@Inject
+	private ConfigurationAdmin caService;
+
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(configureTomcat(),
+				mavenBundle("org.apache.felix", "org.apache.felix.configadmin", "1.4.0"));
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException, IOException {
+		org.osgi.service.cm.Configuration config = caService.getConfiguration(WebContainerConstants.PID);
+
+		Dictionary<String, Object> props = new Hashtable<>();
+
+		props.put(WebContainerConstants.PROPERTY_LISTENING_ADDRESSES, "127.0.0.1");
+		props.put(WebContainerConstants.PROPERTY_HTTP_PORT, "8282");
+
+		config.setBundleLocation(null);
+		config.update(props);
+
+		String bundlePath = "mvn:org.ops4j.pax.web.samples/helloworld-hs/" + VersionUtil.getProjectVersion();
+		installWarBundle = installAndStartBundle(bundlePath);
+
+		waitForServer("http://127.0.0.1:8282/");
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testSubPath() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Hello World'",
+						resp -> resp.contains("Hello World"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/helloworld/hs");
+		// test image-serving
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/images/logo.png");
+	}
+
+	@Test
+	public void testRootPath() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/");
+	}
+
+	@Test
+	public void testServletPath() throws Exception {
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Servlet Path: '",
+						resp -> resp.contains("Servlet Path: "))
+				.withResponseAssertion("Response must contain 'Path Info: /lall/blubb'",
+						resp -> resp.contains("Path Info: /lall/blubb"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/lall/blubb");
+	}
+
+	@Test
+	public void testServletDeRegistration() throws Exception {
+
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+		}
+	}
+
+	/**
+	 * Tests reconfiguration to another port
+	 *
+	 * @throws Exception when any error occurs
+	 */
+	@Test
+	public void testReconfiguration() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Servlet Path: '",
+						resp -> resp.contains("Servlet Path: "))
+				.withResponseAssertion("Response must contain 'Path Info: /lall/blubb'",
+						resp -> resp.contains("Path Info: /lall/blubb"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/lall/blubb");
+
+		org.osgi.service.cm.Configuration config = caService.getConfiguration(WebContainerConstants.PID);
+
+		Dictionary<String, Object> props = new Hashtable<>();
+
+		props.put(WebContainerConstants.PROPERTY_LISTENING_ADDRESSES, "127.0.0.1");
+		props.put(WebContainerConstants.PROPERTY_HTTP_PORT, "9191");
+
+		config.setBundleLocation(null);
+		config.update(props);
+
+		waitForServer("http://127.0.0.1:9191/");
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Servlet Path: '",
+						resp -> resp.contains("Servlet Path: "))
+				.withResponseAssertion("Response must contain 'Path Info: /lall/blubb'",
+						resp -> resp.contains("Path Info: /lall/blubb"))
+				.doGETandExecuteTest("http://127.0.0.1:9191/lall/blubb");
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithoutCMIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithoutCMIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+
+
+/**
+ * @author Toni Menzel (tonit)
+ * @since Mar 3, 2009
+ */
+@RunWith(PaxExam.class)
+public class HttpServiceWithoutCMIntegrationTest extends ITestBase {
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public static Option[] configure() {
+		return configureTomcat();
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		initWebListener();
+		String bundlePath = "mvn:org.ops4j.pax.web.samples/helloworld-hs/" + VersionUtil.getProjectVersion();
+		installWarBundle = installAndStartBundle(bundlePath);
+		waitForWebListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testSubPath() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Hello World'",
+						resp -> resp.contains("Hello World"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/helloworld/hs");
+		// test image-serving
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/images/logo.png");
+	}
+
+	@Test
+	public void testRootPath() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/");
+	}
+
+	@Test
+	public void testServletPath() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Servlet Path: '",
+						resp -> resp.contains("Servlet Path: "))
+				.withResponseAssertion("Response must contain 'Path Info: /lall/blubb'",
+						resp -> resp.contains("Path Info: /lall/blubb"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/lall/blubb");
+	}
+
+	@Test
+	public void testServletDeRegistration() throws Exception {
+
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+		}
+	}
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JerseyCustomContextIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JerseyCustomContextIntegrationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.OptionUtils;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+
+/**
+ * @author Toni Menzel (tonit)
+ * @since Mar 3, 2009
+ */
+@RunWith(PaxExam.class)
+public class JerseyCustomContextIntegrationTest extends ITestBase {
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public static Option[] configure() {
+		return OptionUtils
+				.combine(
+						configureTomcat(),
+						mavenBundle().groupId("com.sun.jersey")
+								.artifactId("jersey-core")
+								.version("1.19"),
+						mavenBundle().groupId("com.sun.jersey")
+								.artifactId("jersey-server")
+								.version("1.19"),
+						mavenBundle().groupId("com.sun.jersey")
+								.artifactId("jersey-servlet")
+								.version("1.19"),
+						mavenBundle().groupId("javax.ws.rs")
+								.artifactId("jsr311-api")
+								.version("1.1.1")
+				);
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		String bundlePath = "mvn:org.ops4j.pax.web.samples/web-jersey/"
+				+ VersionUtil.getProjectVersion();
+		installWarBundle = installAndStartBundle(bundlePath);
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testRoot() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'New session created'",
+						resp -> resp.contains("New session created"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/");
+		// test image-serving
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/images/success.png");
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JspSelfRegistrationIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JspSelfRegistrationIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.jsp.JasperClassLoader;
+import org.ops4j.pax.web.jsp.JspServletWrapper;
+import org.osgi.framework.Bundle;
+import org.osgi.service.http.HttpContext;
+import org.osgi.service.http.HttpService;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+
+/**
+ * The tests contained here will test the usage of the PAX Web Jsp directly with the HttpService, without
+ * the need for a full servlet container environment. This is useful when integrating PAX Web JSP into an
+ * existing servlet container using an HTTP Bridge service implementation such as the Felix Http bridge
+ * service implementation.
+ * <p>
+ * This test validates the correction for PAXWEB-497 as well as the new functionality from PAXWEB-498.
+ *
+ * @author Serge Huber
+ */
+@RunWith(PaxExam.class)
+public class JspSelfRegistrationIntegrationTest extends ITestBase {
+
+
+	@Configuration
+	public static Option[] configure() {
+		return configureTomcat();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		initServletListener(null);
+		waitForServletListener();
+//		waitForServer("http://127.0.0.1:8181/");
+	}
+
+	/**
+	 * Test the class loader parent bug described in PAXWEB-497
+	 */
+	@Test
+	public void testJSPEngineClassLoaderParent() throws Exception {
+		HttpService httpService = getHttpService(bundleContext);
+
+		initServletListener(null);
+
+		String urlAlias = "/jsp/jspSelfRegistrationTest.jsp";
+		JspServletWrapper servlet = new JspServletWrapper(bundleContext.getBundle(), urlAlias);
+		HttpContext customHttpContext = httpService.createDefaultHttpContext();
+		httpService.registerServlet(urlAlias, servlet, null, customHttpContext);
+
+		waitForServletListener();
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'TEST OK'",
+						resp -> resp.contains("TEST OK"))
+				.doGETandExecuteTest("http://127.0.0.1:8282" + urlAlias);
+
+		Assert.assertEquals("Class loader " + servlet.getClassLoader().getParent() + " is not expected class loader parent",
+				JasperClassLoader.class.getClassLoader(),
+				servlet.getClassLoader().getParent());
+
+		httpService.unregister(urlAlias);
+	}
+
+
+	/**
+	 * Tests the custom class loader described in PAXWEB-498
+	 */
+	@Test
+	public void testJSPEngineCustomClassLoader() throws Exception {
+		HttpService httpService = getHttpService(bundleContext);
+
+		initServletListener(null);
+
+		String urlAlias = "/jsp/jspSelfRegistrationTest.jsp";
+		LoggingJasperClassLoader loggingJasperClassLoader = new LoggingJasperClassLoader(bundleContext.getBundle(), JasperClassLoader.class.getClassLoader());
+		JspServletWrapper servlet = new JspServletWrapper(urlAlias, loggingJasperClassLoader);
+		HttpContext customHttpContext = httpService.createDefaultHttpContext();
+		httpService.registerServlet(urlAlias, servlet, null, customHttpContext);
+
+		waitForServletListener();
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'TEST OK'",
+						resp -> resp.contains("TEST OK"))
+				.doGETandExecuteTest("http://127.0.0.1:8282" + urlAlias);
+
+//   		testClient.testWebPath("http://127.0.0.1:8181" + urlAlias, "TEST OK");
+
+		String classLoaderLog = loggingJasperClassLoader.getLogBuilder().toString();
+		System.out.println("classLoaderLog:\n" + classLoaderLog);
+		Assert.assertTrue("Logging class loader didn't log anything !", classLoaderLog.length() > 0);
+
+		httpService.unregister(urlAlias);
+	}
+
+	private static class LoggingJasperClassLoader extends JasperClassLoader {
+
+		StringBuilder logBuilder = new StringBuilder();
+
+		LoggingJasperClassLoader(Bundle bundle, ClassLoader parent) {
+			super(bundle, parent);
+		}
+
+		@Override
+		public URL getResource(String name) {
+			logBuilder.append("getResource(").append(name).append(")\n");
+			return super.getResource(name);
+		}
+
+		@Override
+		public Enumeration<URL> getResources(String name) throws IOException {
+			logBuilder.append("getResources(").append(name).append(")\n");
+			return super.getResources(name);
+		}
+
+		@Override
+		public Class<?> loadClass(String name) throws ClassNotFoundException {
+			logBuilder.append("loadClass(").append(name).append(")\n");
+			return super.loadClass(name);
+		}
+
+		StringBuilder getLogBuilder() {
+			return logBuilder;
+		}
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/SharedContextFilterIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/SharedContextFilterIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.FilterBundleActivator;
+import org.ops4j.pax.web.itest.base.support.ServletBundleActivator;
+import org.ops4j.pax.web.itest.base.support.SimpleOnlyFilter;
+import org.ops4j.pax.web.itest.base.support.TestServlet;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+/**
+ * @author Achim Nierbeck (anierbeck)
+ * @since Dec 30, 2012
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class SharedContextFilterIntegrationTest extends ITestBase {
+
+	private static final String SERVLET_BUNDLE = "ServletBundleTest";
+	private static final String FILTER_BUNDLE = "FilterBundleTest";
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(
+				configureTomcat(),
+				streamBundle(bundle()
+						.add(TestServlet.class)
+						.add(ServletBundleActivator.class)
+						.set(Constants.BUNDLE_SYMBOLICNAME, SERVLET_BUNDLE)
+						.set(Constants.BUNDLE_ACTIVATOR,
+								ServletBundleActivator.class.getName())
+						.set(Constants.DYNAMICIMPORT_PACKAGE, "*").build()),
+				streamBundle(bundle()
+						.add(SimpleOnlyFilter.class)
+						.add(FilterBundleActivator.class)
+						.set(Constants.BUNDLE_SYMBOLICNAME, FILTER_BUNDLE)
+						.set(Constants.BUNDLE_ACTIVATOR,
+								FilterBundleActivator.class.getName())
+						.set(Constants.DYNAMICIMPORT_PACKAGE, "*").build()));
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		waitForServer("http://127.0.0.1:8282/");
+	}
+
+
+	@Test
+	public void testBundle1() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Hello Whiteboard Filter'",
+						resp -> resp.contains("Hello Whiteboard Filter"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/sharedContext/");
+	}
+
+	@Test
+	public void testStop() throws Exception {
+		for (final Bundle b : bundleContext.getBundles()) {
+			if (FILTER_BUNDLE.equalsIgnoreCase(b.getSymbolicName())) {
+				b.stop();
+			}
+		}
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'SimpleServlet: TEST OK'",
+						resp -> resp.contains("SimpleServlet: TEST OK"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/sharedContext/");
+	}
+
+	@Test
+	public void testStopServletBundle() throws Exception {
+		for (final Bundle b : bundleContext.getBundles()) {
+			if (SERVLET_BUNDLE.equalsIgnoreCase(b.getSymbolicName())) {
+				b.stop();
+			}
+		}
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withReturnCode(404)
+				.doGETandExecuteTest("http://127.0.0.1:8282/sharedContext/");
+	}
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/SharedFilterIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/SharedFilterIntegrationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.*;
+import org.osgi.framework.Constants;
+
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+
+/**
+ * @author Achim Nierbeck (anierbeck)
+ * @since Dec 30, 2012
+ */
+@RunWith(PaxExam.class)
+public class SharedFilterIntegrationTest extends ITestBase {
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(configureTomcat(),
+				streamBundle(bundle()
+						.add(Bundle1Servlet.class)
+						.add(Bundle1Filter.class)
+						.add(Bundle1SharedFilter.class)
+//		                .add(SharedContext.class)
+						.add(Bundle1Activator.class)
+						.set(Constants.BUNDLE_SYMBOLICNAME, "BundleTest1")
+						.set(Constants.BUNDLE_ACTIVATOR, Bundle1Activator.class.getName())
+						.set(Constants.DYNAMICIMPORT_PACKAGE, "*")
+						.build()),
+				streamBundle(bundle()
+						.add(Bundle2SharedServlet.class)
+						.add(Bundle2SharedFilter.class)
+						.add(Bundle2Activator.class)
+						.set(Constants.BUNDLE_SYMBOLICNAME, "BundleTest2")
+						.set(Constants.BUNDLE_ACTIVATOR, Bundle2Activator.class.getName())
+						.set(Constants.DYNAMICIMPORT_PACKAGE, "*")
+						.build()));
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		waitForServer("http://127.0.0.1:8282/");
+	}
+
+
+	@Test
+	public void testBundle1() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Welcome to Bundle1'",
+						resp -> resp.contains("Welcome to Bundle1"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/bundle1/");
+		HttpTestClientFactory.createDefaultTestClient()
+				.withReturnCode(404)
+				.doGETandExecuteTest("http://127.0.0.1:8282/bundle2/");
+	}
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/SimultaneousWhiteboardIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/SimultaneousWhiteboardIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.extender.samples.whiteboard.internal.WhiteboardFilter;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.TestActivator;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.streamBundle;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+
+/**
+ * @author Toni Menzel (tonit)
+ * @since Mar 3, 2009
+ */
+@RunWith(PaxExam.class)
+@Ignore
+public class SimultaneousWhiteboardIntegrationTest extends ITestBase {
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(
+				configureTomcat(),
+				mavenBundle().groupId("org.ops4j.pax.web.samples")
+						.artifactId("whiteboard").version(asInProject()).noStart(),
+				streamBundle(
+						bundle().add(TestActivator.class)
+								.add(WhiteboardFilter.class)
+								.set(Constants.BUNDLE_ACTIVATOR, TestActivator.class.getName())
+								.set(Constants.BUNDLE_SYMBOLICNAME,
+										"org.ops4j.pax.web.itest.SimultaneousTest")
+								.set(Constants.DYNAMICIMPORT_PACKAGE, "*")
+								.build()).noStart());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		Bundle whiteBoardBundle = null;
+		Bundle simultaneousTestBundle = null;
+
+		Bundle[] bundles = bundleContext.getBundles();
+		for (Bundle bundle : bundles) {
+			String symbolicName = bundle.getSymbolicName();
+			if ("org.ops4j.pax.web.extender.samples.whiteboard".equals(symbolicName)) {
+				whiteBoardBundle = bundle;
+			} else if ("org.ops4j.pax.web.itest.SimultaneousTest".equals(symbolicName)) {
+				simultaneousTestBundle = bundle;
+			}
+		}
+
+		assertNotNull(simultaneousTestBundle);
+		assertNotNull(whiteBoardBundle);
+
+		simultaneousTestBundle.start();
+		whiteBoardBundle.start();
+	}
+
+
+	@Test
+	public void testWhiteBoardRoot() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Hello Whiteboard Extender'",
+						resp -> resp.contains("Hello Whiteboard Extender"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/root");
+	}
+
+	@Test
+	public void testWhiteBoardSlash() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Welcome to the Welcome page'",
+						resp -> resp.contains("Welcome to the Welcome page"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/");
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WabJettyWebIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WabJettyWebIntegrationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The test bundle is named wab-jetty-web but is actually not jetty related
+ * 
+ * @author Sergey Beryozkin
+ */
+@RunWith(PaxExam.class)
+public class WabJettyWebIntegrationTest extends ITestBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WabJettyWebIntegrationTest.class);
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public static Option[] configure() {
+		return configureTomcat();
+	}
+
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		LOG.info("Setting up test");
+
+		initWebListener();
+
+		String bundlePath = "mvn:org.ops4j.pax.web.samples/wab-jetty-web/"
+				+ VersionUtil.getProjectVersion() + "/jar";
+
+		installWarBundle = bundleContext.installBundle(bundlePath);
+		installWarBundle.start();
+
+		waitForWebListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testDispatchJsp() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'It works'",
+						resp -> resp.contains("It works"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/wab-jetty-web/index.html");
+	}
+
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarFormAuthIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarFormAuthIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+/**
+ * @author Achim Nierbeck
+ */
+@RunWith(PaxExam.class)
+public class WarFormAuthIntegrationTest extends ITestBase {
+
+	private static final Logger LOG = LoggerFactory
+			.getLogger(WarFormAuthIntegrationTest.class);
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public static Option[] configurationDetailed() {
+		return combine(
+				configureTomcat(),
+				mavenBundle().groupId("org.ops4j.pax.web.samples")
+						.artifactId("tomcat-auth-config-fragment")
+						.version(VersionUtil.getProjectVersion()).noStart());
+
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		LOG.info("Setting up test");
+
+		initWebListener();
+
+		String bundlePath = WEB_BUNDLE
+				+ "mvn:org.ops4j.pax.web.samples/war-formauth/"
+				+ VersionUtil.getProjectVersion() + "/war?" + WEB_CONTEXT_PATH
+				+ "=/war-formauth";
+		installWarBundle = bundleContext.installBundle(bundlePath);
+		installWarBundle.start();
+
+		waitForWebListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+	@Test
+	public void testWC() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-formauth/wc");
+	}
+
+	@Test
+	@Ignore("Use Form-Submit with Jetty HttpClient")
+	public void testWebContainerExample() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<title>Login Page for Examples</title>'",
+						resp -> resp.contains("<title>Login Page for Examples</title>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-formauth/wc/example");
+	}
+
+	@Test
+	public void testWebContainerSN() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-formauth/wc/sn");
+	}
+
+	@Ignore
+	@Test
+	public void testSlash() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-formauth/");
+	}
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFPrimefacesIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFPrimefacesIntegrationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.OptionUtils;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.TestConfiguration;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.CookieState;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.MavenUtils.asInProject;
+
+/**
+ * @author Achim Nierbeck
+ */
+@RunWith(PaxExam.class)
+public class WarJSFPrimefacesIntegrationTest extends ITestBase {
+
+	private static final Logger LOG = LoggerFactory
+			.getLogger(WarJSFPrimefacesIntegrationTest.class);
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public static Option[] configure() {
+
+		return OptionUtils
+				.combine(
+						configureTomcat(),
+						TestConfiguration.jsfBundlesWithDependencies(),
+						mavenBundle().groupId("org.primefaces").artifactId("primefaces").version(asInProject())
+				);
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		final Bundle[] bundles = bundleContext.getBundles();
+		for (final Bundle bundle : bundles) {
+			if ("org.apache.myfaces.core.api".equalsIgnoreCase(bundle
+					.getSymbolicName())
+					|| "org.apache.myfaces.core.impl".equalsIgnoreCase(bundle
+					.getSymbolicName())) {
+				bundle.stop();
+				bundle.start();
+			}
+		}
+
+		LOG.info("Setting up test");
+
+		initWebListener();
+
+		final String bundlePath = "mvn:org.ops4j.pax.web.samples/war-jsf-primefaces/"
+				+ VersionUtil.getProjectVersion() + "/war";
+		installWarBundle = bundleContext.installBundle(bundlePath);
+		installWarBundle.start();
+
+		waitForWebListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testSlash() throws Exception {
+		// needed to wait for fully initializing the container
+		Thread.sleep(1000);
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Please enter your name'",
+						resp -> resp.contains("Please enter your name"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-primefaces-sample/");
+	}
+
+	@Test
+	@Ignore("This does work in the browser but not in the test")
+	public void testJSF() throws Exception {
+		// needed to wait for fully initializing the container
+		Thread.sleep(1000);
+
+		// Session must be kept during test-requests
+		CookieState cookieState = new CookieState();
+
+		final String response = HttpTestClientFactory.createDefaultTestClient()
+				.useCookieState(cookieState)
+				.withResponseAssertion("Response must contain 'Please enter your name'",
+						resp -> resp.contains("Please enter your name"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-primefaces-sample/");
+
+		String intermediate = response.substring(response.indexOf("name=\"javax.faces.ViewState\""));
+		int indexOf = intermediate.indexOf("value=\"");
+		String substring = intermediate.substring(indexOf + 7);
+		indexOf = substring.indexOf("\"");
+		substring = substring.substring(0, indexOf);
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.useCookieState(cookieState)
+				//.withResponseAssertion("Response must contain 'Hello Dummy-User. We hope you enjoy Apache MyFaces'",
+				//		resp -> resp.contains("Hello Dummy-User. We hope you enjoy Apache MyFaces"))
+				.doPOST("http://127.0.0.1:8282/war-jsf-primefaces-sample/")
+				.addParameter("mainForm:name", "Dummy-User")
+				.addParameter("mainForm:j_id_b", "Press+me")
+				.addParameter("javax.faces.ViewState", substring)
+				.addParameter("mainForm_SUBMIT", "1")
+				.executeTest();
+	}
+
+	@Test
+	@Ignore("what is wrong with the panelGrid?")
+	public void testPrimefacesTagRendering() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Please enter your name'",
+						resp -> resp.contains("Please enter your name"))
+				.withResponseAssertion("The Primefaces-tag <p:panelGrid> was not rendered correctly.",
+						resp -> !resp.matches("(?s).*<p:panelGrid.*>.*</p:panelGrid>.*"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-primefaces-sample/");
+	}
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJsfCdiIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJsfCdiIntegrationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+
+import static org.ops4j.pax.exam.CoreOptions.*;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+@RunWith(PaxExam.class)
+public class WarJsfCdiIntegrationTest extends ITestBase {
+
+    private static String VERSION_PAX_CDI = "1.0.0-SNAPSHOT";
+
+    private Option[] configureJsfAndCdi() {
+        return options(
+                systemProperty("org.ops4j.pax.logging.DefaultServiceLog.level").value("INFO"),
+                mavenBundle("org.apache.felix", "org.apache.felix.configadmin").version("1.8.10"),
+                // API
+                mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.javax-inject").version("1_2"),
+                mavenBundle("javax.enterprise", "cdi-api").version("1.2"),
+                mavenBundle("javax.validation", "validation-api").version("1.1.0.Final"),
+                mavenBundle("javax.annotation", "javax.annotation-api").version("1.2"),
+                mavenBundle("javax.interceptor", "javax.interceptor-api").version("1.2"),
+                // Common
+                mavenBundle("com.google.guava", "guava").version("19.0"),
+                mavenBundle("commons-io", "commons-io").version("1.4"),
+                mavenBundle("commons-codec", "commons-codec").version("1.10"),
+                mavenBundle("commons-beanutils", "commons-beanutils").version("1.8.3"),
+                mavenBundle("commons-collections", "commons-collections").version("3.2.1"),
+                mavenBundle("commons-digester", "commons-digester").version("1.8.1"),
+                mavenBundle("org.apache.commons", "commons-lang3").version("3.4"),
+                // JSF
+                mavenBundle("org.glassfish", "javax.faces").version("2.2.13"),
+                // Weld
+                mavenBundle("org.jboss.classfilewriter", "jboss-classfilewriter").version("1.1.2.Final"),
+                mavenBundle("org.jboss.logging", "jboss-logging").version("3.3.0.Final"),
+                mavenBundle("org.jboss.weld", "weld-osgi-bundle").version("2.4.0.Final")
+        );
+    }
+
+    @Configuration
+    public Option[] config() {
+        return combine(configureTomcat(), configureJsfAndCdi());
+    }
+
+    @Before
+    public void setUp() throws Exception{
+        // Pax-CDI started later, because order is important
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-api").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-spi").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-extender").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-extension").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-servlet").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-web").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-web-weld").version(VERSION_PAX_CDI).getURL());
+        installAndStartBundle(mavenBundle().groupId("org.ops4j.pax.cdi").artifactId("pax-cdi-weld").version(VERSION_PAX_CDI).getURL());
+    }
+
+    @Test
+    @Ignore
+    public void testCdi() throws Exception {
+        // prepare Bundle
+        initWebListener();
+        installAndStartBundle(mavenBundle()
+                .groupId("org.ops4j.pax.web.samples")
+                .artifactId("war-jsf-cdi")
+                .versionAsInProject()
+                .getURL());
+
+        waitForWebListener();
+        // Test
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Hello from CDI-Managed SessionBean'",
+						resp -> resp.contains("Hello from CDI-Managed SessionBean"))
+                .withResponseAssertion("Response must contain 'Hello from OSGi-Service'",
+                        resp -> resp.contains("Hello from OSGi-Service"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war-jsf-cdi/index.xhtml");
+//        testClient.testWebPath("http://localhost:8181/war-jsf-cdi/index.xhtml", "Hello from CDI-Managed SessionBean");
+    }
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WebFragmentIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WebFragmentIntegrationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.BundleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+
+/**
+ * @author Achim Nierbeck
+ */
+@RunWith(PaxExam.class)
+public class WebFragmentIntegrationTest extends ITestBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WebFragmentIntegrationTest.class);
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(configureTomcat(),
+				mavenBundle().groupId("org.ops4j.pax.web.samples.web-fragment").artifactId("war").versionAsInProject(),
+				mavenBundle().groupId("org.ops4j.pax.web.samples.web-fragment").artifactId("fragment").versionAsInProject()
+		);
+	}
+
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		LOG.info("Setting up test");
+
+		initWebListener();
+		waitForWebListener();
+	}
+
+
+	@Test
+	@Ignore("Filter issue")
+	public void testWC() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.withResponseAssertion("Response must contain 'Have bundle context in filter: true'",
+						resp -> resp.contains("Have bundle context in filter: true"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc");
+	}
+
+	@Test
+	@Ignore("Filter issue")
+	public void testFilterInit() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain 'Have bundle context in filter: true'",
+						resp -> resp.contains("Have bundle context in filter: true"))
+				.withResponseAssertion("Response must contain 'Hello World (url pattern)' from Filter set in web.xml",
+						resp -> resp.contains("Hello World (url pattern)"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc");
+	}
+
+	@Test
+	public void testWebContainerExample() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc/example");
+
+		HttpTestClientFactory.createDefaultTestClient()
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/images/logo.png");
+	}
+
+	@Test
+	public void testWebContainerSN() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h1>Hello World</h1>'",
+						resp -> resp.contains("<h1>Hello World</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc/sn");
+	}
+
+	@Test
+	public void testSlash() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withReturnCode(404)
+				.withResponseAssertion("Response must contain '<h1>Error Page</h1>'",
+						resp -> resp.contains("<h1>Error Page</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/");
+	}
+
+
+	@Test
+	public void testSubJSP() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withResponseAssertion("Response must contain '<h2>Hello World!</h2>'",
+						resp -> resp.contains("<h2>Hello World!</h2>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc/subjsp");
+	}
+
+	@Test
+	public void testErrorJSPCall() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withReturnCode(404)
+				.withResponseAssertion("Response must contain '<h1>Error Page</h1>'",
+						resp -> resp.contains("<h1>Error Page</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wc/error.jsp");
+	}
+
+	@Test
+	public void testWrongServlet() throws Exception {
+		HttpTestClientFactory.createDefaultTestClient()
+				.withReturnCode(404)
+				.withResponseAssertion("Response must contain '<h1>Error Page</h1>'",
+						resp -> resp.contains("<h1>Error Page</h1>"))
+				.doGETandExecuteTest("http://127.0.0.1:8282/war/wrong/");
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardServletAnnotatedIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardServletAnnotatedIntegrationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.AnnotatedTestFilter;
+import org.ops4j.pax.web.itest.base.support.AnnotatedTestServlet;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceRegistration;
+
+import javax.servlet.Filter;
+import javax.servlet.Servlet;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+/**
+ * @author Achim Nierbeck (anierbeck)
+ * @since Dec 30, 2012
+ */
+@RunWith(PaxExam.class)
+public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
+
+	@Configuration
+	public static Option[] configure() {
+		return combine(configureTomcat());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+	}
+
+	@Test
+	public void testWhiteboardServletRegistration() throws Exception {
+
+		ServiceRegistration<Servlet> servletRegistration = bundleContext
+				.registerService(Servlet.class, new AnnotatedTestServlet(),
+						null);
+
+		try {
+			HttpTestClientFactory.createDefaultTestClient()
+					.withResponseAssertion("Response must contain 'TEST OK'",
+							resp -> resp.contains("TEST OK"))
+					.doGETandExecuteTest("http://127.0.0.1:8282/test");
+		} finally {
+			servletRegistration.unregister();
+		}
+
+	}
+
+	@Test
+	public void testWhiteboardServletRegistrationDestroyCalled() throws Exception {
+
+		AnnotatedTestServlet annotatedTestServlet = new AnnotatedTestServlet();
+
+		ServiceRegistration<Servlet> servletRegistration = bundleContext
+				.registerService(Servlet.class, annotatedTestServlet,
+						null);
+
+		try {
+			HttpTestClientFactory.createDefaultTestClient()
+					.withResponseAssertion("Response must contain 'TEST OK'",
+							resp -> resp.contains("TEST OK"))
+					.doGETandExecuteTest("http://127.0.0.1:8282/test");
+		} finally {
+			servletRegistration.unregister();
+		}
+
+		assertThat(annotatedTestServlet.isInitCalled(), is(true));
+		assertThat(annotatedTestServlet.isDestroyCalled(), is(true));
+	}
+
+	@Test
+	@Ignore
+	public void testWhiteboardFilterRegistration() throws Exception {
+
+		ServiceRegistration<Servlet> servletRegistration = bundleContext
+				.registerService(Servlet.class, new AnnotatedTestServlet(),
+						null);
+
+		ServiceRegistration<Filter> filterRegistration = bundleContext
+				.registerService(Filter.class, new AnnotatedTestFilter(), null);
+
+		try {
+			HttpTestClientFactory.createDefaultTestClient()
+					.withResponseAssertion("Response must contain 'TEST OK'",
+							resp -> resp.contains("TEST OK"))
+					.withResponseAssertion("Response must contain 'FILTER-INIT: true'",
+							resp -> resp.contains("FILTER-INIT: true"))
+					.doGETandExecuteTest("http://127.0.0.1:8282/test");
+		} finally {
+			servletRegistration.unregister();
+			filterRegistration.unregister();
+		}
+
+	}
+}

--- a/pax-web-tomcat-bundle/pom.xml
+++ b/pax-web-tomcat-bundle/pom.xml
@@ -58,8 +58,7 @@
 							javax.security.auth,
 							javax.security.auth.callback,
 							javax.security.auth.login,
-							javax.servlet.descriptor;
-							javax.security.cert;
+							javax.security.cert,
 							resolution:=optional;version="[2.3.0,3.1.0)",
 							javax.xml.parsers,
 							org.osgi.framework;version="[1.0.0,2.0.0)",


### PR DESCRIPTION
Copy and adapt a reasonable number of integration tests from Jetty to Tomcat

Some features (like filter registration in whiteboard patterns) do not seem to work, but now we have at least tests for those (even though they are ignored for now).