### PR TITLE
[PAXWEB-1075] Try to make integration tests for tomcat more robust

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
 import org.ops4j.pax.web.itest.base.VersionUtil;
 import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
 import org.ops4j.pax.web.service.WebContainerConstants;
@@ -43,6 +45,7 @@ import static org.ops4j.pax.exam.OptionUtils.combine;
  * @since Mar 3, 2009
  */
 @RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
 public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 
 	private Bundle installWarBundle;

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JerseyCustomContextIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JerseyCustomContextIntegrationTest.java
@@ -64,7 +64,9 @@ public class JerseyCustomContextIntegrationTest extends ITestBase {
 		String bundlePath = "mvn:org.ops4j.pax.web.samples/web-jersey/"
 				+ VersionUtil.getProjectVersion();
 		installWarBundle = installAndStartBundle(bundlePath);
-	}
+
+		waitForServer("http://127.0.0.1:8282/");
+}
 
 	@After
 	public void tearDown() throws BundleException {

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardR6DtoIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardR6DtoIntegrationTest.java
@@ -77,7 +77,9 @@ public class WhiteboardR6DtoIntegrationTest extends ITestBase {
 	public void setUp() throws Exception {
 		initServletListener();
 		waitForServletListener();
-	}
+
+		waitForServer("http://127.0.0.1:8282/");
+}
 
 	@Test
 	public void testAllSamplesRegisteredAsExpected() throws Exception {
@@ -123,7 +125,7 @@ public class WhiteboardR6DtoIntegrationTest extends ITestBase {
 		ServiceTracker<HttpServiceRuntime, HttpServiceRuntime> st = new ServiceTracker<HttpServiceRuntime, HttpServiceRuntime>(bundleContext, HttpServiceRuntime.class, null);
 		st.open();
 		try {
-		    HttpServiceRuntime service = st.waitForService(2000);
+		    HttpServiceRuntime service = st.waitForService(3000);
             if(service != null){
                 result = function.apply(service);
             }


### PR DESCRIPTION
The tests run locally but some fail on jenkins. This may be a timing issue. This is an attempt to make the tests more robust to timing issues.