### PR TITLE
[PAXWEB-1075] Try to make integration tests for tomcat more robust

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
@@ -76,6 +76,9 @@ public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 		installWarBundle = installAndStartBundle(bundlePath);
 
 		waitForServer("http://127.0.0.1:8282/");
+
+		// Wait a second. This is really ugly but without that the tests flicker
+		Thread.sleep(1000);
 	}
 
 	@After

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardServletAnnotatedIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardServletAnnotatedIntegrationTest.java
@@ -23,6 +23,8 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
 import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
 import org.ops4j.pax.web.itest.base.support.AnnotatedTestFilter;
 import org.ops4j.pax.web.itest.base.support.AnnotatedTestServlet;
@@ -41,6 +43,7 @@ import static org.ops4j.pax.exam.OptionUtils.combine;
  * @since Dec 30, 2012
  */
 @RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
 public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 
 	@Configuration
@@ -64,6 +67,8 @@ public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 				.registerService(Servlet.class, new AnnotatedTestServlet(),
 						null);
 
+		waitForServer("http://127.0.0.1:8282/test");
+		
 		try {
 			HttpTestClientFactory.createDefaultTestClient()
 					.withResponseAssertion("Response must contain 'TEST OK'",
@@ -83,6 +88,8 @@ public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 		ServiceRegistration<Servlet> servletRegistration = bundleContext
 				.registerService(Servlet.class, annotatedTestServlet,
 						null);
+
+		waitForServer("http://127.0.0.1:8282/test");
 
 		try {
 			HttpTestClientFactory.createDefaultTestClient()

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -522,12 +522,18 @@ class TomcatServerWrapper implements ServerWrapper {
 		}
 
 		final Context context = contextMap.remove(httpContext);
-		this.server.getHost().removeChild(context);
 		if (context == null) {
 			throw new RemoveContextException(
 					"cannot remove the context because it does not exist: "
 							+ httpContext);
 		}
+		try {
+			context.stop();
+		} catch (LifecycleException e) {
+			throw new RemoveContextException("cannot stop the context: "
+					+ httpContext, e);
+		}
+		this.server.getHost().removeChild(context);
 		try {
 			final LifecycleState state = context.getState();
 			if (LifecycleState.DESTROYED != state


### PR DESCRIPTION
Two of the new tests still flicker. This is another attempt to fix this.

The WhiteboardServletAnnotatedIntegrationTest also sometimes triggers an Exception in TomcatServerWrapper. host.removeChild(context) will call a destroy() on context (which will fail if it is still running), so I stop the context before (this will just do nothing if the context is already stopped).