### PR TITLE
[PAXWEB-1075] Try to use ServletListeners to wait instead of sleep()

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
@@ -72,13 +72,12 @@ public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 		config.setBundleLocation(null);
 		config.update(props);
 
+		initServletListener();
+
 		String bundlePath = "mvn:org.ops4j.pax.web.samples/helloworld-hs/" + VersionUtil.getProjectVersion();
 		installWarBundle = installAndStartBundle(bundlePath);
 
-		waitForServer("http://127.0.0.1:8282/");
-
-		// Wait a second. This is really ugly but without that the tests flicker
-		Thread.sleep(1500);
+		waitForServletListener();
 	}
 
 	@After
@@ -147,13 +146,13 @@ public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 		props.put(WebContainerConstants.PROPERTY_LISTENING_ADDRESSES, "127.0.0.1");
 		props.put(WebContainerConstants.PROPERTY_HTTP_PORT, "9191");
 
+		initServletListener();
+
 		config.setBundleLocation(null);
 		config.update(props);
 
 		waitForServer("http://127.0.0.1:9191/");
-
-		// Wait a second. This is really ugly but without that the tests flicker
-		Thread.sleep(1500);
+		waitForServletListener();
 
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain 'Servlet Path: '",

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JerseyCustomContextIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/JerseyCustomContextIntegrationTest.java
@@ -63,12 +63,14 @@ public class JerseyCustomContextIntegrationTest extends ITestBase {
 	public void setUp() throws BundleException, InterruptedException {
 		String bundlePath = "mvn:org.ops4j.pax.web.samples/web-jersey/"
 				+ VersionUtil.getProjectVersion();
+
+		initServletListener();
+
 		installWarBundle = installAndStartBundle(bundlePath);
 
 		waitForServer("http://127.0.0.1:8282/");
 
-		// Wait a second. This is really ugly but without that the tests flicker
-		Thread.sleep(1500);
+		waitForServletListener();
 }
 
 	@After

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardServletAnnotatedIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardServletAnnotatedIntegrationTest.java
@@ -41,7 +41,6 @@ import static org.ops4j.pax.exam.OptionUtils.combine;
  * @since Dec 30, 2012
  */
 @RunWith(PaxExam.class)
-@Ignore("These tests run locally but they randomly fail on the CI jenkins")
 public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 
 	@Configuration
@@ -61,13 +60,14 @@ public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 	@Test
 	public void testWhiteboardServletRegistration() throws Exception {
 
+		initServletListener();
+
 		ServiceRegistration<Servlet> servletRegistration = bundleContext
 				.registerService(Servlet.class, new AnnotatedTestServlet(),
 						null);
 
-		// Wait a second. This is really ugly but without that the tests flicker
-		Thread.sleep(1500);
-		
+		waitForServletListener();
+
 		try {
 			HttpTestClientFactory.createDefaultTestClient()
 					.withResponseAssertion("Response must contain 'TEST OK'",
@@ -84,12 +84,13 @@ public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 
 		AnnotatedTestServlet annotatedTestServlet = new AnnotatedTestServlet();
 
+		initServletListener();
+		
 		ServiceRegistration<Servlet> servletRegistration = bundleContext
 				.registerService(Servlet.class, annotatedTestServlet,
 						null);
 
-		// Wait a second. This is really ugly but without that the tests flicker
-		Thread.sleep(1500);
+		waitForServletListener();
 
 		try {
 			HttpTestClientFactory.createDefaultTestClient()
@@ -108,6 +109,8 @@ public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 	@Ignore
 	public void testWhiteboardFilterRegistration() throws Exception {
 
+		initServletListener();
+
 		ServiceRegistration<Servlet> servletRegistration = bundleContext
 				.registerService(Servlet.class, new AnnotatedTestServlet(),
 						null);
@@ -115,8 +118,7 @@ public class WhiteboardServletAnnotatedIntegrationTest extends ITestBase {
 		ServiceRegistration<Filter> filterRegistration = bundleContext
 				.registerService(Filter.class, new AnnotatedTestFilter(), null);
 
-		// Wait a second. This is really ugly but without that the tests flicker
-		Thread.sleep(1500);
+		waitForServletListener();
 
 		try {
 			HttpTestClientFactory.createDefaultTestClient()


### PR DESCRIPTION
Try to synchronize with ServletListeners instead of sleep() calls. This will hopefully not break the jenkins build again.