### PR TITLE
[PAXWEB-1075] ServletListener does not work for server reconfiguration

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
@@ -146,13 +146,13 @@ public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 		props.put(WebContainerConstants.PROPERTY_LISTENING_ADDRESSES, "127.0.0.1");
 		props.put(WebContainerConstants.PROPERTY_HTTP_PORT, "9191");
 
-		initServletListener();
-
 		config.setBundleLocation(null);
 		config.update(props);
 
 		waitForServer("http://127.0.0.1:9191/");
-		waitForServletListener();
+
+		// give the container time to start the servlet again in the new server
+		Thread.sleep(1500);
 
 		HttpTestClientFactory.createDefaultTestClient()
 				.withResponseAssertion("Response must contain 'Servlet Path: '",


### PR DESCRIPTION
This is hopefully the final pull request for this. The ServletListeners work in most cases, but not in this particular one (where we reconfigure the server to a different port).