### PR TITLE
[PAXWEB-1078] Fix cookie handling in test client

### DIFF
--- a/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/client/CookieState.java
+++ b/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/client/CookieState.java
@@ -15,9 +15,8 @@
  */
 package org.ops4j.pax.web.itest.base.client;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
+import java.net.CookieManager;
+import java.net.CookieStore;
 
 /**
  * Stores Cookie-Data for further Requests.
@@ -26,13 +25,9 @@ import java.util.stream.Stream;
  */
 public class CookieState {
 
-	private Map<String, String> state = new HashMap<>();
+	private CookieStore cookieStore = new CookieManager().getCookieStore();
 
-	Stream<Map.Entry<String, String>> getStateValues() {
-		return state.entrySet().stream();
-	}
-
-	void putAll(Map<String, String> cookies) {
-		this.state.putAll(cookies);
+	CookieStore getCookieStore() {
+		return cookieStore;
 	}
 }

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFPrimefacesIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WarJSFPrimefacesIntegrationTest.java
@@ -104,7 +104,6 @@ public class WarJSFPrimefacesIntegrationTest extends ITestBase {
 	}
 
 	@Test
-	@Ignore("This does work in the browser but not in the test")
 	public void testJSF() throws Exception {
 		// needed to wait for fully initializing the container
 		Thread.sleep(1000);
@@ -126,8 +125,8 @@ public class WarJSFPrimefacesIntegrationTest extends ITestBase {
 
 		HttpTestClientFactory.createDefaultTestClient()
 				.useCookieState(cookieState)
-				//.withResponseAssertion("Response must contain 'Hello Dummy-User. We hope you enjoy Apache MyFaces'",
-				//		resp -> resp.contains("Hello Dummy-User. We hope you enjoy Apache MyFaces"))
+				.withResponseAssertion("Response must contain 'Hello Dummy-User. We hope you enjoy Apache MyFaces'",
+						resp -> resp.contains("Hello Dummy-User. We hope you enjoy Apache MyFaces"))
 				.doPOST("http://127.0.0.1:8282/war-jsf-primefaces-sample/")
 				.addParameter("mainForm:name", "Dummy-User")
 				.addParameter("mainForm:j_id_b", "Press+me")


### PR DESCRIPTION
This pull request replaces that hand-crafted cookie handling in the itest client by the one provided by the underlying Jetty HttpClient. In the consequence the CookieState class is just a wrapper for an (in-memory) CookieStore. If present, this CookieStore is set to the Jetty HttpClient and that one will handle all the cookies.

This is important because the test in question does acutally a redirect and without that change the cookies will get lost in the redirect.