### PR TITLE
Prevent NoClassDefFoundError caused by org/apache/tomcat/InstanceManager

### DIFF
--- a/pax-web-jsp/pom.xml
+++ b/pax-web-jsp/pom.xml
@@ -218,6 +218,7 @@
 							org.apache.taglibs.standard.tag.rt.xml,
 							org.apache.taglibs.standard.tei,
 							org.apache.taglibs.standard.tlv,
+                            org.apache.tomcat,
 							org.apache.tomcat.util.descriptor.tld
 						</Export-Package>
 						<Include-Resource> {maven-dependencies},


### PR DESCRIPTION
https://ops4j1.jira.com/browse/PAXWEB-1058