### PR TITLE
[PAXWEB-1077] wait till the servlets are up again after bundle restart

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardDSRestartIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardDSRestartIntegrationTest.java
@@ -107,11 +107,14 @@ public class WhiteboardDSRestartIntegrationTest extends ITestBase {
 				.waitForCondition(10000, 500, () -> fail("Whiteboard bundle did not stop in time"));
 
 		// start Whiteboard bundle again
+		initServletListener();
 		whiteBoardBundle.start();
 
 		new WaitCondition2("Check if Whiteboard bundle gets activated",
 				() -> whiteBoardBundle.getState() == Bundle.ACTIVE)
 				.waitForCondition(10000, 500, () -> fail("Whiteboard bundle did not start in time"));
+		// also wait till the servlet is registered
+		waitForServletListener();
 
 		// Test
 		HttpTestClientFactory.createDefaultTestClient()

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardDSRestartIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardDSRestartIntegrationTest.java
@@ -115,7 +115,7 @@ public class WhiteboardDSRestartIntegrationTest extends ITestBase {
 				.waitForCondition(10000, 500, () -> fail("Whiteboard bundle did not start in time"));
 		// also wait till the servlet is registered
 		waitForServletListener();
-		Thread.sleep(1000);
+		Thread.sleep(1500);
 
 		// Test
 		HttpTestClientFactory.createDefaultTestClient()

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardDSRestartIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardDSRestartIntegrationTest.java
@@ -115,6 +115,7 @@ public class WhiteboardDSRestartIntegrationTest extends ITestBase {
 				.waitForCondition(10000, 500, () -> fail("Whiteboard bundle did not start in time"));
 		// also wait till the servlet is registered
 		waitForServletListener();
+		Thread.sleep(1000);
 
 		// Test
 		HttpTestClientFactory.createDefaultTestClient()

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardRestartTCIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardRestartTCIntegrationTest.java
@@ -118,11 +118,14 @@ public class WhiteboardRestartTCIntegrationTest extends ITestBase {
 				.waitForCondition(10000, 500, () -> fail("Whiteboard bundle did not stop in time"));
 
 		// start Whiteboard bundle again
+		initServletListener();
 		whiteBoardBundle.start();
 
 		new WaitCondition2("Check if Whiteboard bundle gets activated",
 				() -> whiteBoardBundle.getState() == Bundle.ACTIVE)
 				.waitForCondition(10000, 500, () -> fail("Whiteboard bundle did not start in time"));
+		// also wait till the servlet is registered
+		waitForServletListener();
 
 		// Test
 		HttpTestClientFactory.createDefaultTestClient()


### PR DESCRIPTION
The test with the Tomcat server fails on the build server. We may need to wait till the servlet is running again before continuing with the test