### PR TITLE
[PAXWEB-629] Configure Tomcat via context.xml

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/TomcatResourceConfigurationIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/TomcatResourceConfigurationIntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.VersionUtil;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Achim Nierbeck
+ */
+@RunWith(PaxExam.class)
+public class TomcatResourceConfigurationIntegrationTest extends ITestBase {
+
+	private Bundle installWarBundle;
+
+	@Configuration
+	public Option[] configure() {
+	    // delete the access log before the server starts
+	    purgeLogDir();
+		return combine(
+				configureTomcat(),
+				mavenBundle().groupId("org.ops4j.pax.web.samples")
+						.artifactId("tomcat-config-fragment")
+						.version(VersionUtil.getProjectVersion()).noStart());
+
+	}
+
+	@Before
+	public void setUp() throws BundleException, InterruptedException {
+		logger.info("Setting up test");
+
+		initWebListener();
+
+		final String bundlePath = WEB_BUNDLE
+				+ "mvn:org.ops4j.pax.web.samples/war-tomcat-resource/" + VersionUtil.getProjectVersion()
+				+ "/war?" + WEB_CONTEXT_PATH + "=/resource";
+		installWarBundle = bundleContext.installBundle(bundlePath);
+		installWarBundle.start();
+
+		waitForWebListener();
+	}
+
+	@After
+	public void tearDown() throws BundleException {
+		if (installWarBundle != null) {
+			installWarBundle.stop();
+			installWarBundle.uninstall();
+		}
+	}
+
+
+	@Test
+	public void testStaticContent() throws Exception {
+		File sample = new File("target/logs/test.log");
+		sample.createNewFile();
+		try (FileOutputStream fos = new FileOutputStream(sample)) {
+			fos.write("Test Output".getBytes(StandardCharsets.UTF_8));
+		}
+	    HttpTestClientFactory.createDefaultTestClient()
+	            .withResponseAssertion("Response must contain 'Test Output'",
+	                    resp -> resp.contains("Test Output"))
+	            .doGETandExecuteTest("http://127.0.0.1:8282/resource/static-content?filename=test.log");
+	    // the valve configured in the tomcat-server.xml should have written an access log
+	    checkAccessLog();
+	}
+
+    private void checkAccessLog() {
+        File[] files = getLogDir().listFiles(new FilenameFilter(){
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.matches("localhost_access_log.*log");
+            }});
+        Assert.assertTrue("http access log is missing", files.length == 1);
+    }
+
+	private static void purgeLogDir() {
+	    purgeDirectory(getLogDir());
+	}
+
+	private static File getLogDir() {
+	    File logDir = new File("target/logs");
+	    if (logDir.exists() && !logDir.isDirectory()) {
+	        logDir.delete();
+	    }
+	    if (!logDir.exists()) {
+	        logDir.mkdirs();
+	    }
+	    return logDir;
+	}
+	
+	private static void purgeDirectory(File dir) {
+	    for (File file: dir.listFiles()) {
+	        if (!file.isDirectory()) file.delete();
+	    }
+	}
+}

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/EmbeddedTomcat.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/EmbeddedTomcat.java
@@ -156,7 +156,7 @@ public class EmbeddedTomcat extends Tomcat {
 
 	private Boolean configurationSessionCookieHttpOnly;
 
-	private String configurationWorkerName;
+	private File configurationDir;
 
 	private EmbeddedTomcat() {
 	}
@@ -215,7 +215,8 @@ public class EmbeddedTomcat extends Tomcat {
 			tomcatResource = getClass().getResource("/tomcat-server.xml");
 		}
 
-		File configurationFile = new File(configuration.getConfigurationDir(),
+		configurationDir = configuration.getConfigurationDir();
+		File configurationFile = new File(configurationDir,
 				SERVER_CONFIG_FILE_NAME);
 		if (configurationFile.exists()) {
 			try {
@@ -272,7 +273,6 @@ public class EmbeddedTomcat extends Tomcat {
 		configurationSessionCookie = configuration.getSessionCookie();
 		configurationSessionCookieHttpOnly = configuration
 				.getSessionCookieHttpOnly();
-		configurationWorkerName = configuration.getWorkerName();
 
 		// NCSA Logger --> AccessLogValve
 		if (configuration.isLogNCSAFormatEnabled()) {
@@ -495,6 +495,10 @@ public class EmbeddedTomcat extends Tomcat {
 
 	String getBasedir() {
 		return basedir;
+	}
+
+	File getConfigurationDir() {
+		return configurationDir;
 	}
 
 	public Context findContext(ContextModel contextModel) {

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/HttpServiceContext.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/HttpServiceContext.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletContext;
 
 import org.apache.catalina.Globals;
 import org.apache.catalina.Host;
+import org.apache.catalina.WebResourceRoot;
 import org.apache.catalina.core.ApplicationContext;
 import org.apache.catalina.core.StandardContext;
 import org.ops4j.pax.web.service.WebContainerContext;
@@ -116,9 +117,22 @@ public class HttpServiceContext extends StandardContext {
 				if (LOG.isDebugEnabled()) {
 					LOG.debug("found resource: " + resource);
 				}
+				if (resource != null) {
+					return resource;
+				}
 			} catch (PrivilegedActionException e) {
 				LOG.warn("Unauthorized access: " + e.getMessage());
 			}
+
+			// the HttpServiceContext might contain resources
+	        WebResourceRoot resources = getResources();
+	        if (resources != null) {
+	            resource = resources.getResource(path).getURL();
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("found resource: " + resource);
+				}
+	        }
+
 			return resource;
 
 		}

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -82,6 +82,7 @@
     <module>jsp-filter</module>
     <module>simple-filter</module>
     <module>war-jetty-web</module>
+    <module>war-tomcat-resource</module>
     <module>war-simple</module>
     <module>war-spring</module>
     <module>war-spring-osgi</module>

--- a/samples/tomcat-config-fragment/src/main/resources/context.xml
+++ b/samples/tomcat-config-fragment/src/main/resources/context.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<Context privileged="true">
+    <Resources allowLinking="true">
+         <PreResources className="org.apache.catalina.webresources.DirResourceSet" base="target" internalPath="/logs" webAppMount="/static-content"/>
+    </Resources>
+</Context>

--- a/samples/war-tomcat-resource/pom.xml
+++ b/samples/war-tomcat-resource/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<relativePath>../pom.xml</relativePath>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>samples</artifactId>
+		<version>6.1.0-SNAPSHOT</version>
+	</parent>
+
+	<groupId>org.ops4j.pax.web.samples</groupId>
+	<artifactId>war-tomcat-resource</artifactId>
+	<packaging>war</packaging>
+
+	<name>OPS4J Pax Web - Samples - WAR Extender - Tomcat Resource</name>
+
+	<properties>
+		<bundle.symbolicName>org.ops4j.pax.web.extender.samples.war.tomcat.resource</bundle.symbolicName>
+		<bundle.namespace>org.ops4j.pax.web.extender.samples.war.tomcat.resource</bundle.namespace>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<!-- Provided dependencies -->
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>${servlet.spec.groupId}</groupId>
+			<artifactId>${servlet.spec.artifactId}</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/samples/war-tomcat-resource/src/main/java/org/ops4j/pax/web/extender/samples/war/internal/ResourceServlet.java
+++ b/samples/war-tomcat-resource/src/main/java/org/ops4j/pax/web/extender/samples/war/internal/ResourceServlet.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.extender.samples.war.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class ResourceServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -9137418274335254420L;
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String filename = request.getParameter("filename");
+        URL resource = request.getServletContext().getResource("/static-content/" + filename);
+        if (resource != null) {
+            File file = new File(resource.getPath());
+            response.setHeader("Content-Type", getServletContext().getMimeType(filename));
+            response.setHeader("Content-Length", String.valueOf(file.length()));
+            response.setHeader("Content-Disposition", "inline; filename=\"" + file.getName() + "\"");
+            Files.copy(file.toPath(), response.getOutputStream());
+        }
+    }
+
+    @Override
+    public void destroy() {
+        log("destroying servlet");
+        System.out.println("servlet Destroyed");
+        super.destroy();
+    }
+}

--- a/samples/war-tomcat-resource/src/main/webapp/WEB-INF/web.xml
+++ b/samples/war-tomcat-resource/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+-->
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <display-name>Pax Web Extender WAR Tomcat Resource Sample</display-name>
+
+    <servlet>
+        <servlet-name>resource.servlet</servlet-name>
+        <servlet-class>org.ops4j.pax.web.extender.samples.war.internal.ResourceServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>resource.servlet</servlet-name>
+        <url-pattern>/static-content</url-pattern>
+    </servlet-mapping>
+</web-app>


### PR DESCRIPTION
This patch will allow to configure contexts either with a default context.xml in a configuration fragment or in the configuration directory or with a war specific META-INF/context.xml inside the war.
