### PR TITLE
[PAXWEB-1110] always set loginConfig on context

### DIFF
--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -979,20 +979,20 @@ class TomcatServerWrapper implements ServerWrapper {
 			}
 		}
 
+		String authMethod = contextModel.getAuthMethod();
+		if (authMethod == null) {
+			authMethod = "NONE";
+		}
+		String realmName = contextModel.getRealmName();
+		String loginPage = contextModel.getFormLoginPage();
+		String errorPage = contextModel.getFormErrorPage();
+		LoginConfig loginConfig = new LoginConfig(authMethod, realmName, loginPage, errorPage);
+		context.setLoginConfig(loginConfig);
+		LOG.debug("loginConfig: method={} realm={}", authMethod, realmName);
+		// Custom Service Valve for checking authentication stuff ...
+		context.getPipeline().addValve(new ServiceValve(httpContext));
 		if (context.getAuthenticator() == null) {
-			String authMethod = contextModel.getAuthMethod();
-			if (authMethod == null) {
-				authMethod = "NONE";
-			}
-			String realmName = contextModel.getRealmName();
-			String loginPage = contextModel.getFormLoginPage();
-			String errorPage = contextModel.getFormErrorPage();
-			LoginConfig loginConfig = new LoginConfig(authMethod, realmName, loginPage, errorPage);
-			context.setLoginConfig(loginConfig);
-			LOG.debug("method={} realm={}", authMethod, realmName);
-			// Custom Service Valve for checking authentication stuff ...
-			context.getPipeline().addValve(new ServiceValve(httpContext));
-			// Custom OSGi Security
+			// Authentication Valve according to configured authentication method
 			context.getPipeline().addValve(getAuthenticatorValve(authMethod));
 		}
 


### PR DESCRIPTION
In plain tomcat the LoginConfig object is created by the web.xml digester and set to the context in the ContextConfig class. In Pax-Web the web.xml is parsed by the extender, so we have to create the LoginConfig ourselves.

We also need to do this in case the authentication valve is defined in the context configuration (which is e.g. necessary if creating a non-default charset on a form valve). In this case the valve still needs to access the information from the context-config (e.g. the login page or the error page).