### PR TITLE
synchronized some methods

### DIFF
--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerImpl.java
@@ -337,7 +337,7 @@ class JettyServerImpl implements JettyServer {
 	}
 
 	@Override
-	public void addServlet(final ServletModel model) {
+	public synchronized void addServlet(final ServletModel model) {
 		LOG.debug("Adding servlet [" + model + "]");
 		final ServletMapping mapping = new ServletMapping();
 		mapping.setServletName(model.getName());
@@ -406,7 +406,7 @@ class JettyServerImpl implements JettyServer {
 	}
 
 	@Override
-	public void removeServlet(final ServletModel model) {
+	public synchronized void removeServlet(final ServletModel model) {
 		LOG.debug("Removing servlet [" + model + "]");
 		// jetty does not provide a method for removing a servlet so we have to
 		// do it by our own
@@ -483,7 +483,7 @@ class JettyServerImpl implements JettyServer {
 	}
 
 	@Override
-	public void removeEventListener(final EventListenerModel model) {
+	public synchronized void removeEventListener(final EventListenerModel model) {
 		final ServletContextHandler context = server.getContext(model
 				.getContextModel().getHttpContext());
 
@@ -517,7 +517,7 @@ class JettyServerImpl implements JettyServer {
 	}
 
 	@Override
-	public void addFilter(final FilterModel model) {
+	public synchronized void addFilter(final FilterModel model) {
 		LOG.debug("Adding filter model [" + model + "]");
 		final FilterMapping mapping = new FilterMapping();
 		mapping.setFilterName(model.getName());
@@ -597,7 +597,7 @@ class JettyServerImpl implements JettyServer {
 	}
 
 	@Override
-	public void removeFilter(FilterModel model) {
+	public synchronized void removeFilter(FilterModel model) {
 		LOG.debug("Removing filter model [" + model + "]");
 		final ServletContextHandler context = server.getContext(model
 				.getContextModel().getHttpContext());


### PR DESCRIPTION
In some linux environment, I encounter this problem:

```
2017-07-06 10:17:22,686 | ERROR | rint Extender: 1 | WebApplication                  :273 | 198 - org.ops4j.pax.web.pax-web-extender-whiteboard - 4.3.0 | Registration skipped for [ServletWebElement{mapping=DefaultServletMapping{httpContextId=ncontext,urlPatterns=null,initParams={},servlet=com.fidoie.app.rest.RestPublisher$RestServlet@5e95f9a3, alias=/rest/joblog, servletNamenull}}] due to error during registration
java.lang.IllegalStateException: No such servlet: org.ops4j.pax.web.service.spi.model.ServletModel-51
	at org.eclipse.jetty.servlet.ServletHandler.updateMappings(ServletHandler.java:1471)[172:org.eclipse.jetty.servlet:9.2.19.v20160908]
	at org.eclipse.jetty.servlet.ServletHandler.setServletMappings(ServletHandler.java:1585)[172:org.eclipse.jetty.servlet:9.2.19.v20160908]
	at org.eclipse.jetty.servlet.ServletHandler.addServletMapping(ServletHandler.java:1023)[172:org.eclipse.jetty.servlet:9.2.19.v20160908]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl$2.call(JettyServerImpl.java:355)[199:org.ops4j.pax.web.pax-web-jetty:4.3.0]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl$2.call(JettyServerImpl.java:350)[199:org.ops4j.pax.web.pax-web-jetty:4.3.0]
	at org.ops4j.pax.swissbox.core.ContextClassLoaderUtils.doWithClassLoader(ContextClassLoaderUtils.java:60)[199:org.ops4j.pax.web.pax-web-jetty:4.3.0]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl.addServlet(JettyServerImpl.java:349)[199:org.ops4j.pax.web.pax-web-jetty:4.3.0]
	at org.ops4j.pax.web.service.jetty.internal.ServerControllerImpl$Started.addServlet(ServerControllerImpl.java:290)[199:org.ops4j.pax.web.pax-web-jetty:4.3.0]
	at org.ops4j.pax.web.service.jetty.internal.ServerControllerImpl.addServlet(ServerControllerImpl.java:110)[199:org.ops4j.pax.web.pax-web-jetty:4.3.0]
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.registerServlet(HttpServiceStarted.java:217)[201:org.ops4j.pax.web.pax-web-runtime:4.3.0]
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.registerServlet(HttpServiceStarted.java:196)[201:org.ops4j.pax.web.pax-web-runtime:4.3.0]
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.registerServlet(HttpServiceStarted.java:180)[201:org.ops4j.pax.web.pax-web-runtime:4.3.0]
	at org.ops4j.pax.web.service.internal.HttpServiceProxy.registerServlet(HttpServiceProxy.java:64)[201:org.ops4j.pax.web.pax-web-runtime:4.3.0]
	at org.ops4j.pax.web.extender.whiteboard.internal.element.ServletWebElement.register(ServletWebElement.java:61)[198:org.ops4j.pax.web.pax-web-extender-whiteboard:4.3.0]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.registerWebElement(WebApplication.java:270)[198:org.ops4j.pax.web.pax-web-extender-whiteboard:4.3.0]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.addWebElement(WebApplication.java:127)[198:org.ops4j.pax.web.pax-web-extender-whiteboard:4.3.0]
	at org.ops4j.pax.web.extender.whiteboard.internal.tracker.AbstractTracker.addingService(AbstractTracker.java:169)[198:org.ops4j.pax.web.pax-web-extender-whiteboard:4.3.0]
	at org.ops4j.pax.web.extender.whiteboard.internal.tracker.AbstractTracker.addingService(AbstractTracker.java:44)[198:org.ops4j.pax.web.pax-web-extender-whiteboard:4.3.0]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:941)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:870)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:229)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:901)[org.osgi.core-6.0.0.jar:]
	at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4557)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.Felix.registerService(Felix.java:3549)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.BundleContextImpl.registerService(BundleContextImpl.java:348)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.BundleContextImpl.registerService(BundleContextImpl.java:322)[org.apache.felix.framework-5.6.1.jar:]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:941)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:870)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:229)[org.osgi.core-6.0.0.jar:]
	at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:901)[org.osgi.core-6.0.0.jar:]
	at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4557)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.Felix.registerService(Felix.java:3549)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.felix.framework.BundleContextImpl.registerService(BundleContextImpl.java:348)[org.apache.felix.framework-5.6.1.jar:]
	at org.apache.aries.blueprint.container.BlueprintContainerImpl.registerService(BlueprintContainerImpl.java:492)[211:org.apache.aries.blueprint.core:1.7.1]
	at org.apache.aries.blueprint.container.ServiceRecipe.register(ServiceRecipe.java:193)[211:org.apache.aries.blueprint.core:1.7.1]
	at org.apache.aries.blueprint.container.BlueprintContainerImpl.registerServices(BlueprintContainerImpl.java:746)[211:org.apache.aries.blueprint.core:1.7.1]
	at org.apache.aries.blueprint.container.BlueprintContainerImpl.doRun(BlueprintContainerImpl.java:413)[211:org.apache.aries.blueprint.core:1.7.1]
	at org.apache.aries.blueprint.container.BlueprintContainerImpl.run(BlueprintContainerImpl.java:276)[211:org.apache.aries.blueprint.core:1.7.1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)[:1.7.0_55]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)[:1.7.0_55]
	at org.apache.aries.blueprint.container.ExecutorServiceWrapper.run(ExecutorServiceWrapper.java:106)[211:org.apache.aries.blueprint.core:1.7.1]
	at org.apache.aries.blueprint.utils.threading.impl.DiscardableRunnable.run(DiscardableRunnable.java:48)[211:org.apache.aries.blueprint.core:1.7.1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)[:1.7.0_55]
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)[:1.7.0_55]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178)[:1.7.0_55]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292)[:1.7.0_55]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)[:1.7.0_55]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)[:1.7.0_55]
	at java.lang.Thread.run(Thread.java:745)[:1.7.0_55]
```

so, I think we should synchronized this methods.