### PR TITLE
[PAXWEB-1129] Update to Tomcat 8.5.20

### DIFF
--- a/pax-web-features/src/main/resources/features.xml
+++ b/pax-web-features/src/main/resources/features.xml
@@ -153,6 +153,7 @@
         <feature>scr</feature>
         <feature version="[6.1,6.2)">pax-http</feature>
         <bundle dependency="true" start-level="30">mvn:javax.el/javax.el-api/3.0.0</bundle>
+        <bundle dependency="true" start-level="30">mvn:javax.security.auth.message/javax.security.auth.message-api/${dependency.jaspic.version}</bundle>
         <bundle dependency="true" start-level="30">mvn:org.ops4j.pax.tipi/org.ops4j.pax.tipi.tomcat-embed-core/${tipi.tomcat.version}</bundle>
         <bundle dependency="true" start-level="30">mvn:org.ops4j.pax.tipi/org.ops4j.pax.tipi.tomcat-embed-websocket/${tipi.tomcat.version}</bundle>
         <bundle dependency="true" start-level="30">mvn:${servlet.spec.groupId}/${servlet.spec.artifactId}/${servlet.spec.version}</bundle>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/pom.xml
@@ -362,6 +362,12 @@
 			<artifactId>javax.interceptor-api</artifactId>
 			<version>1.2</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.security.auth.message</groupId>
+			<artifactId>javax.security.auth.message-api</artifactId>
+			<version>${dependency.jaspic.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/ITestBase.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/ITestBase.java
@@ -107,6 +107,9 @@ public class ITestBase extends AbstractTestBase {
 						.version(asInProject()),
 				mavenBundle().groupId("org.apache.geronimo.specs")
 						.artifactId("geronimo-osgi-registry")
+						.version(asInProject()),
+				mavenBundle().groupId("javax.security.auth.message")
+						.artifactId("javax.security.auth.message-api")
 						.version(asInProject())
 		);
 	}

--- a/pax-web-jsp/pom.xml
+++ b/pax-web-jsp/pom.xml
@@ -86,6 +86,7 @@
 							org.ops4j.pax.web.utils,
 							javax.sql; resolution:=optional,
 							javax.xml.parsers,
+							javax.xml.stream,
 							javax.xml.validation; resolution:=optional,
 							javax.xml.namespace; resolution:=optional,
 							javax.xml.transform.*; resolution:=optional,
@@ -333,11 +334,6 @@
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-core</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.tomcat.embed</groupId>
-			<artifactId>tomcat-embed-logging-juli</artifactId>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pax-web-jsp/src/main/java/org/apache/jasper/JspCompilationContext.java
+++ b/pax-web-jsp/src/main/java/org/apache/jasper/JspCompilationContext.java
@@ -152,7 +152,7 @@ public class JspCompilationContext {
     /** ---------- Class path and loader ---------- */
 
     /**
-     * The classpath that is passed off to the Java compiler.
+     * @return the classpath that is passed off to the Java compiler.
      */
     public String getClassPath() {
         if( classPath != null ) {
@@ -163,6 +163,7 @@ public class JspCompilationContext {
 
     /**
      * The classpath that is passed off to the Java compiler.
+     * @param classPath The class path to use
      */
     public void setClassPath(String classPath) {
         this.classPath = classPath;
@@ -171,6 +172,7 @@ public class JspCompilationContext {
     /**
      * What class loader to use for loading classes while compiling
      * this JSP?
+     * @return the class loader used to load all compiled classes
      */
     public ClassLoader getClassLoader() {
         if( loader != null ) {
@@ -204,6 +206,7 @@ public class JspCompilationContext {
      * The output directory to generate code into.  The output directory
      * is make up of the scratch directory, which is provide in Options,
      * plus the directory derived from the package name.
+     * @return the output directory in which the generated sources are placed
      */
     public String getOutputDir() {
         if (outputDir == null) {
@@ -217,6 +220,7 @@ public class JspCompilationContext {
      * Create a "Compiler" object based on some init param data. This
      * is not done yet. Right now we're just hardcoding the actual
      * compilers that are created.
+     * @return the Java compiler wrapper
      */
     public Compiler createCompiler() {
         if (jspCompiler != null ) {
@@ -275,6 +279,8 @@ public class JspCompilationContext {
     /**
      * Get the full value of a URI relative to this compilations context
      * uses current file as the base.
+     * @param uri The relative URI
+     * @return absolute URI
      */
     public String resolveRelativeUri(String uri) {
         // sometimes we get uri's massaged from File(String), so check for
@@ -289,6 +295,7 @@ public class JspCompilationContext {
     /**
      * Gets a resource as a stream, relative to the meanings of this
      * context's implementation.
+     * @param res the resource to look for
      * @return a null if the resource cannot be found or represented
      *         as an InputStream.
      */
@@ -309,6 +316,8 @@ public class JspCompilationContext {
     /**
      * Gets the actual path of a URI relative to the context of
      * the compilation.
+     * @param path The webapp path
+     * @return the corresponding path in the filesystem
      */
     public String getRealPath(String path) {
         if (context != null) {
@@ -322,6 +331,7 @@ public class JspCompilationContext {
      * JspCompilationContext was created is packaged, or null if this
      * JspCompilationContext does not correspond to a tag file, or if the
      * corresponding tag file is not packaged in a JAR.
+     * @return a JAR file
      */
     public Jar getTagFileJar() {
         return this.tagJar;
@@ -336,6 +346,7 @@ public class JspCompilationContext {
     /**
      * Just the class name (does not include package name) of the
      * generated class.
+     * @return the class name
      */
     public String getServletClassName() {
 
@@ -363,6 +374,7 @@ public class JspCompilationContext {
     /**
      * Path of the JSP URI. Note that this is not a file name. This is
      * the context rooted URI of the JSP file.
+     * @return the path to the JSP
      */
     public String getJspFile() {
         return jspUri;
@@ -436,9 +448,10 @@ public class JspCompilationContext {
     }
 
     /**
-     * True if we are compiling a tag file in prototype mode.
-     * ie we only generate codes with class for the tag handler with empty
-     * method bodies.
+     * @return <code>true</code> if we are compiling a tag file
+     *  in prototype mode.
+     *  ie we only generate codes with class for the tag handler with empty
+     *  method bodies.
      */
     public boolean isPrototypeMode() {
         return protoTypeMode;
@@ -452,6 +465,7 @@ public class JspCompilationContext {
      * Package name for the generated class is make up of the base package
      * name, which is user settable, and the derived package name.  The
      * derived package name directly mirrors the file hierarchy of the JSP page.
+     * @return the package name
      */
     public String getServletPackageName() {
         if (isTagFile()) {
@@ -493,13 +507,14 @@ public class JspCompilationContext {
 
     /**
      * The package name into which the servlet class is generated.
+     * @param servletPackageName The package name to use
      */
     public void setServletPackageName(String servletPackageName) {
         this.basePackageName = servletPackageName;
     }
 
     /**
-     * Full path name of the Java file into which the servlet is being
+     * @return Full path name of the Java file into which the servlet is being
      * generated.
      */
     public String getServletJavaFileName() {
@@ -510,7 +525,7 @@ public class JspCompilationContext {
     }
 
     /**
-     * Get hold of the Options object for this context.
+     * @return the Options object for this context.
      */
     public Options getOptions() {
         return options;
@@ -525,7 +540,7 @@ public class JspCompilationContext {
     }
 
     /**
-     * Path of the Java file relative to the work directory.
+     * @return the path of the Java file relative to the work directory.
      */
     public String getJavaPath() {
 
@@ -551,7 +566,7 @@ public class JspCompilationContext {
     }
 
     /**
-     * Where is the servlet being generated?
+     * @return the writer that is used to write the generated Servlet source.
      */
     public ServletWriter getWriter() {
         return writer;
@@ -563,7 +578,7 @@ public class JspCompilationContext {
 
     /**
      * Gets the 'location' of the TLD associated with the given taglib 'uri'.
-     *
+     * @param uri The taglib URI
      * @return An array of two Strings: The first element denotes the real
      * path to the TLD. If the path to the TLD points to a jar file, then the
      * second element denotes the name of the TLD entry in the jar file.
@@ -575,7 +590,7 @@ public class JspCompilationContext {
     }
 
     /**
-     * Are we keeping generated code around?
+     * @return <code>true</code> if generated code is kept.
      */
     public boolean keepGenerated() {
         return getOptions().getKeepGenerated();
@@ -598,7 +613,7 @@ public class JspCompilationContext {
 
     public void compile() throws JasperException, FileNotFoundException {
         createCompiler();
-        if (jspCompiler.isOutDated() || jspCompiler.isOutDated()) { // Pax-Web enhanced
+        if (jspCompiler.isOutDated()) {
             if (isRemoved()) {
                 throw new FileNotFoundException(jspUri);
             }

--- a/pax-web-jsp/src/main/java/org/apache/tomcat/util/descriptor/tagplugin/TagPluginParser.java
+++ b/pax-web-jsp/src/main/java/org/apache/tomcat/util/descriptor/tagplugin/TagPluginParser.java
@@ -36,6 +36,7 @@ import org.xml.sax.SAXException;
 /**
  * Parser for Tag Plugin descriptors.
  */
+@SuppressWarnings("deprecation")
 public class TagPluginParser {
 	private static final Log log = LogFactory.getLog(TagPluginParser.class);
 	private static final String PREFIX = "tag-plugins/tag-plugin";

--- a/pax-web-jsp/src/main/java/org/ops4j/pax/web/jsp/JspServletWrapper.java
+++ b/pax-web-jsp/src/main/java/org/ops4j/pax/web/jsp/JspServletWrapper.java
@@ -27,7 +27,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
-import org.apache.jasper.Constants;
 import org.apache.jasper.servlet.JspServlet;
 import org.ops4j.pax.swissbox.core.ContextClassLoaderUtils;
 import org.osgi.framework.Bundle;
@@ -136,12 +135,11 @@ public class JspServletWrapper implements Servlet {
 	 *
 	 * @see JspServlet#service(ServletRequest, ServletResponse)
 	 */
-	@SuppressWarnings("deprecation")
 	@Override
 	public void service(final ServletRequest req, final ServletResponse res)
 			throws ServletException, IOException {
 		if (jspFile != null) {
-			req.setAttribute(Constants.JSP_FILE, jspFile);
+			req.setAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH, jspFile);
 		}
 		String includeRequestUri = (String) req
 				.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI);

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -88,7 +88,7 @@
 							org.apache.el.util; version="2.2"; resolution:=optional
 							org.apache.catalina,
 							org.apache.catalina.authenticator,
-							org.apache.catalina.comet,
+							org.apache.catalina.authenticator.jaspic,
 							org.apache.catalina.connector,
 							org.apache.catalina.core,
 							org.apache.catalina.deploy,
@@ -112,6 +112,7 @@
 							org.apache.coyote.http11,
 							org.apache.coyote.http11.filters,
 							org.apache.coyote.http11.upgrade,
+							org.apache.coyote.http2,
 							org.apache.naming,
 							org.apache.naming.factory,
 							org.apache.naming.java,

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/OSGiMemoryRealm.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/OSGiMemoryRealm.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Enumeration;
 
 import org.apache.catalina.LifecycleException;
@@ -35,7 +33,6 @@ public class OSGiMemoryRealm extends MemoryRealm {
 
 	private static final Logger log = LoggerFactory.getLogger(OSGiMemoryRealm.class);
 
-	@SuppressWarnings("deprecation")
 	@Override
 	protected void startInternal() throws LifecycleException {
 
@@ -80,16 +77,6 @@ public class OSGiMemoryRealm extends MemoryRealm {
 				//CHECKSTYLE:ON
 			} finally {
 				digester.reset();
-			}
-
-			// Create a MessageDigest instance for credentials, if desired
-			if (digest != null) {
-				try {
-					md = MessageDigest.getInstance(digest);
-				} catch (NoSuchAlgorithmException e) {
-					throw new LifecycleException(sm.getString(
-							"realmBase.algorithm", digest), e);
-				}
 			}
 
 	        if (getCredentialHandler() == null) {

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/HttpServiceContext.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/HttpServiceContext.java
@@ -35,7 +35,6 @@ import org.apache.catalina.WebResourceRoot;
 import org.apache.catalina.core.ApplicationContext;
 import org.apache.catalina.core.StandardContext;
 import org.ops4j.pax.web.service.WebContainerContext;
-import org.osgi.service.http.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatResourceServlet.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatResourceServlet.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.regex.Matcher;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerFactory.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerFactory.java
@@ -17,15 +17,11 @@
 package org.ops4j.pax.web.service.tomcat.internal;
 
 import org.ops4j.pax.web.service.spi.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Romain Gilles
  */
 public class TomcatServerFactory implements ServerFactory {
-	private static final Logger LOG = LoggerFactory
-			.getLogger(TomcatServerFactory.class);
 
 	public TomcatServerFactory() {
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		<dependency.slf4j>1.7.12</dependency.slf4j>
 		<dependency.scr.version>2.0.6</dependency.scr.version>
 		<dependency.swissbox.version>1.8.2</dependency.swissbox.version>
-		<dependency.tomcat.version>8.0.46</dependency.tomcat.version>
+		<dependency.tomcat.version>8.5.20</dependency.tomcat.version>
 		<dependency.xbean.version>4.6-SNAPSHOT</dependency.xbean.version>
 		<dependency.xnio-api.version>3.3.8.Final</dependency.xnio-api.version>
 		<dependency.xnio.version>3.3.8.Final</dependency.xnio.version>
@@ -131,7 +131,7 @@
 		<dependency.pax-cdi.version>1.0.0.RC2</dependency.pax-cdi.version>
 		<version.pax-exam>4.7.0</version.pax-exam>
 
-		<tipi.tomcat.version>8.0.46.1</tipi.tomcat.version>
+		<tipi.tomcat.version>8.5.20.1</tipi.tomcat.version>
 		<jsf-myfaces.version>2.2.10</jsf-myfaces.version>
 
 		<dependency.junit.version>4.11</dependency.junit.version>
@@ -150,6 +150,7 @@
 		<servlet-jsp.spec.version>2.3.1</servlet-jsp.spec.version>
 		<servlet-jstl.spec.version>1.2.1</servlet-jstl.spec.version>
 		<dependency.el-api.version>3.0.0</dependency.el-api.version>
+		<dependency.jaspic.version>1.1</dependency.jaspic.version>
 
 		<!-- Tells Sonar to use JaCoCo as the code coverage tool -->
 		<sonar.skippedModules>pax-web-itest-load</sonar.skippedModules>

--- a/samples/helloworld-jsp/pom.xml
+++ b/samples/helloworld-jsp/pom.xml
@@ -151,12 +151,6 @@
 					</dependency>
 					
 					<dependency>
-						<groupId>org.apache.tomcat.embed</groupId>
-						<artifactId>tomcat-embed-logging-juli</artifactId>
-						<version>${dependency.tomcat.version}</version>
-					</dependency>
-
-					<dependency>
 						<groupId>org.apache.geronimo.bundles</groupId>
 						<artifactId>jstl</artifactId>
 						<version>1.2_1</version>


### PR DESCRIPTION
This is the actual update to Tomcat 8.5.20 intended for the master branch and the upcoming pax-web 6.1.x

The changes in detail:
1. Tomcat 8.5.x supports JASPIC and requires the API bundle for that. I added it to the test dependency and the feature.
2. I updated the code copy in pax-web-jsp (this affects only javadoc comments).
3. Another change required in pax-web-jsp. The constant Constants.JSP_FILE does not exist anymore, the request attribute for the jsp file is now named RequestDispatcher.INCLUDE_SERVLET_PATH.
4. the tomcat-embed-juli jar does not exist anymore (I removed the remaining dependencies)
5. Some changes to pax-web-tomcat were required. Actually, the weird host, engine, and service attributes were removed from the tomcat class, so I could remove some code from the EmbeddedTomcat class.
