### PR TITLE
PAXWEB-1133 - Upgrade to latest Jetty 9.3.x

### DIFF
--- a/pax-web-extender-whiteboard/pom.xml
+++ b/pax-web-extender-whiteboard/pom.xml
@@ -71,6 +71,7 @@
 							javax.security.auth.login,
 							javax.servlet; version="[2.3.0,4.0.0)",
 							javax.servlet.http; version="[2.3.0,4.0.0)",
+							javax.servlet.annotation; version="[2.3.0,4.0.0)",
 							javax.websocket.*; resolution:=optional,,
 							!javax.microedition.io,
 							!javax.security.auth.x500

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<dependency.jdt.groupId>org.eclipse.jdt.core.compiler</dependency.jdt.groupId>
 		<dependency.jdt.artifactId>ecj</dependency.jdt.artifactId>
 		<dependency.jdt.version>4.5.1</dependency.jdt.version>
-		<dependency.jetty.version>9.3.15.v20161220</dependency.jetty.version>
+		<dependency.jetty.version>9.3.21.v20170918</dependency.jetty.version>
 		<dependency.jsr303.version>1.8.0</dependency.jsr303.version>
 		<dependency.jsr305.version>1.3.9_1</dependency.jsr305.version>
 		<dependency.jstl.version>1.2</dependency.jstl.version>


### PR DESCRIPTION
Enabling Vaadin push on Karaf needed a newer Jetty server. Vaadin push depends on Atmosphere runtime 2.4.11.vaadin2 which needs at least Jetty 9.3.19.v20170502 instead of the 9.3.15.v20161220 that lacks the constructor WebSocketServerFactory(ServletContext, policy) in class org.eclipse.jetty.websocket.server.WebSocketServerFactory.
I upgraded to Jetty 9.3.21.v20170918 and added the missing import-package declaration javax.servlet.annotation; version="[2.3.0,4.0.0)" to pax-web-extender-whiteboard.
This allows annotations like @WebInitParamto to be parsed.