### PR TITLE
[PAXWEB-1075] Try to make Tomcat integration tests more robust on Jenkins

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/HttpServiceWithConfigAdminIntegrationTest.java
@@ -69,10 +69,18 @@ public class HttpServiceWithConfigAdminIntegrationTest extends ITestBase {
 		props.put(WebContainerConstants.PROPERTY_LISTENING_ADDRESSES, "127.0.0.1");
 		props.put(WebContainerConstants.PROPERTY_HTTP_PORT, "8282");
 
-		config.setBundleLocation(null);
-		config.update(props);
+		/*
+		 * Tomcat will start a default root context. This will not hurt, but if we initialize the 
+		 * ServletListener too early it will detect this startup and will start the test before the
+		 * Servlet configured here is registered. Therefore we wait for a second before we initialize
+		 * the ServletListener and register the configuration.
+		 */
+		Thread.sleep(1000);
 
 		initServletListener("/");
+
+		config.setBundleLocation(null);
+		config.update(props);
 
 		String bundlePath = "mvn:org.ops4j.pax.web.samples/helloworld-hs/" + VersionUtil.getProjectVersion();
 		installWarBundle = installAndStartBundle(bundlePath);


### PR DESCRIPTION
Another attempt: It seems when the integration tests fail on Jenkins this is because the actual tests starts too early (before the test servelet is successfully deployed).

A reason might be that the ServletListener misinterprets the start of the default context of the container as the start of the test servlet context and proceeds too early.