### PR TITLE
[PAXWEB-597] - Allow multiple HttpContext settings for the root URL

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardTCIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardTCIntegrationTest.java
@@ -17,7 +17,6 @@ package org.ops4j.pax.web.itest.tomcat;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -97,7 +96,6 @@ public class WhiteboardTCIntegrationTest extends ITestBase {
 	}
 
 	@Test
-	@Ignore("Failing for duplicate Context - PAXWEB-597")
 	public void testWhiteBoardForbidden() throws Exception {
 		HttpTestClientFactory.createDefaultTestClient()
 				.withReturnCode(401)

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/ContextSelectionHostValve.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/ContextSelectionHostValve.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.service.tomcat.internal;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.apache.catalina.Contained;
+import org.apache.catalina.Container;
+import org.apache.catalina.Lifecycle;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Valve;
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.mapper.Mapper;
+import org.apache.catalina.mapper.MappingData;
+import org.apache.catalina.valves.ValveBase;
+
+public class ContextSelectionHostValve extends ValveBase {
+
+	Valve standardHostValve;
+	Mapper mapper;
+
+	public ContextSelectionHostValve(Valve standardHostValve, Mapper mapper) {
+		this.standardHostValve = standardHostValve;
+		this.mapper = mapper;
+	}
+
+	@Override
+	public void invoke(Request request, Response response) throws IOException, ServletException {
+		/*
+		 * The OSGi HTTP service (and the whiteboard extender) will create one
+		 * Context with an empty context path per HttpContext. Tomcat will
+		 * interpret this as different context versions.
+		 * 
+		 * At this point all these Contexts will be in the contexts array in the
+		 * mappingData attribute of the request. The context and the wrapper
+		 * element in the mappingData are set to the last element of the
+		 * contexts array (which is the last version for Tomcat).
+		 * 
+		 * This code will select the first context element that has a wrapper
+		 * for the request URI and set the context and wrapper elements in the
+		 * mapping data accordingly. Afterwards the standard host valve is
+		 * executed with the modified request.
+		 */
+		MappingData md = request.getMappingData();
+		if (md.contexts != null && md.contexts.length > 1 && md.wrapper == null) {
+			for (int i = 0; md.wrapper == null && i < md.contexts.length; i++) {
+				md.context = md.contexts[i];
+				mapper.map(md.context, request.getDecodedRequestURIMB(), md);
+			}
+		}
+		standardHostValve.invoke(request, response);
+	}
+
+	@Override
+	public void setContainer(Container container) {
+		super.setContainer(container);
+		if (standardHostValve instanceof Contained) {
+			((Contained) standardHostValve).setContainer(container);
+		}
+	}
+
+	@Override
+	protected void startInternal() throws LifecycleException {
+		super.startInternal();
+		if (standardHostValve instanceof Lifecycle) {
+			((Lifecycle) standardHostValve).start();
+		}
+	}
+
+	@Override
+	protected void stopInternal() throws LifecycleException {
+		super.stopInternal();
+		if (standardHostValve instanceof Lifecycle) {
+			((Lifecycle) standardHostValve).stop();
+		}
+	}
+}

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/EmbeddedTomcat.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/EmbeddedTomcat.java
@@ -33,11 +33,14 @@ import javax.servlet.ServletContainerInitializer;
 import org.apache.catalina.AccessLog;
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
+import org.apache.catalina.Engine;
+import org.apache.catalina.Host;
 import org.apache.catalina.Server;
 import org.apache.catalina.Service;
 import org.apache.catalina.Valve;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.ContainerBase;
+import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.startup.Catalina;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.AccessLogValve;
@@ -545,13 +548,26 @@ public class EmbeddedTomcat extends Tomcat {
 		return ctx;
 	}
 
-	public String generateContextName(String contextName,
-									  HttpContext httpContext) {
+	public String generateContextName(String contextName, HttpContext httpContext) {
+		String contextId;
+		if (httpContext instanceof WebContainerContext) {
+			contextId = ((WebContainerContext) httpContext).getContextId();
+		} else {
+			contextId = null;
+		}
 		String name;
 		if (contextName != null) {
-			name = "[" + contextName + "]-" + httpContext.getClass().getName();
+			if (contextId != null) {
+				name = "[" + contextName + "]-" + contextId;
+			} else {
+				name = "[" + contextName + "]";
+			}
 		} else {
-			name = "[]-" + httpContext.getClass().getName();
+			if (contextId != null) {
+				name = "[]-" + contextId;
+			} else {
+				name = "[]";
+			}
 		}
 		return name;
 	}
@@ -573,4 +589,21 @@ public class EmbeddedTomcat extends Tomcat {
 		LOG.warn(base);
 	}
 
+	@Override
+	public Host getHost() {
+		Engine engine = getEngine();
+		if (engine.findChildren().length > 0) {
+			return (Host) engine.findChildren()[0];
+		}
+		Host host = new StandardHost();
+		/*
+		 * This is almost a copy of super.getHost(), but if (and only if) a new host is created,
+		 * we need to set a new Basic Valve, that changes the dispatch logic
+		 */
+		Valve contextSelect = new ContextSelectionHostValve(host.getPipeline().getBasic(), getService().getMapper());
+		host.getPipeline().setBasic(contextSelect);
+		host.setName(hostname);
+		getEngine().addChild(host);
+		return host;
+	}
 }

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/HttpServiceContext.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/HttpServiceContext.java
@@ -169,9 +169,6 @@ public class HttpServiceContext extends StandardContext {
 		 * Delegate to http context in case that the http context is an
 		 * {@link WebContainerContext}. {@inheritDoc}
 		 */
-		@SuppressWarnings("unchecked")
-		// Cannot remove this warning as it is an issue with the
-		// javax.servlet.ServletContext interface
 		@Override
 		public Set<String> getResourcePaths(final String path) {
 			if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
This patch tackles the issue with having multiple HttpContexts with Tomcat.

The 1:1 mapping of a HttpContext to a Catalina Context remains unchanged (I just modified the context name to contain the ID of the WebContainerContext instead of the classname of the HttpContext).

Instead I replaced the Basic valve of the host entity with a new ContextSelectionHostValve. This valve will try to select the correct context in a given list of contexts and call the standard host valve with this context.