### PR TITLE
[PAXWEB-1135] - Async support for Tomcat

### DIFF
--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/AsyncServletIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/AsyncServletIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
+import org.ops4j.pax.web.itest.base.support.TestServlet;
+import org.ops4j.pax.web.itest.tomcat.support.AsyncServlet;
+import org.osgi.service.http.HttpContext;
+import org.osgi.service.http.HttpService;
+
+/**
+ * @author Grzegorz Grzybek
+ * @since Apr 1, 2016
+ */
+@RunWith(PaxExam.class)
+public class AsyncServletIntegrationTest extends ITestBase {
+
+	@Configuration
+	public static Option[] configure() {
+		return configureTomcat();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		waitForServer("http://127.0.0.1:8282/");
+		HttpService httpService = getHttpService(bundleContext);
+
+		initServletListener(null);
+
+		// servlets in different contexts
+		httpService.registerServlet("/test", new TestServlet(), null, new CustomHttpContext(httpService.createDefaultHttpContext()));
+		httpService.registerServlet("/async", new AsyncServlet(), null, new CustomHttpContext(httpService.createDefaultHttpContext()));
+		waitForServletListener();
+	}
+
+	@Test
+	public void testAsyncResponse() throws Exception {
+		byte[] bytes = new byte[AsyncServlet.SIZE];
+		Arrays.fill(bytes, (byte) 0x42);
+		String expected = new String(bytes);
+
+		HttpTestClientFactory.createDefaultTestClient()
+		.timeoutInSeconds(300)
+				.withResponseAssertion("Must get async response",
+						resp -> resp.contains(expected))
+				.doGET("http://127.0.0.1:8282/async")
+				.executeTest();
+	}
+
+	public static class CustomHttpContext implements HttpContext {
+
+		private HttpContext delegate;
+
+		public CustomHttpContext(HttpContext delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean handleSecurity(HttpServletRequest request, HttpServletResponse response) throws IOException {
+			return delegate.handleSecurity(request, response);
+		}
+
+		@Override
+		public URL getResource(String name) {
+			return delegate.getResource(name);
+		}
+
+		@Override
+		public String getMimeType(String name) {
+			return delegate.getMimeType(name);
+		}
+
+	}
+
+}

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/support/AsyncServlet.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/support/AsyncServlet.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.itest.tomcat.support;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(asyncSupported = true)
+public class AsyncServlet extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+	public static final int SIZE = 1024 + 32;
+	private static final int PART = 128;
+
+	private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+	/**
+	 * Regardless of request path/headers/params, this method will slowly return
+	 * 1kB of data.
+	 * 
+	 * @param req
+	 * @param resp
+	 * @throws ServletException
+	 * @throws IOException
+	 */
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+		switch (req.getDispatcherType()) {
+		case REQUEST:
+			startResponding(req, resp);
+			break;
+		case ASYNC:
+			continueResponding(req, resp);
+			break;
+		default:
+			break;
+		}
+	}
+
+	private void startResponding(final HttpServletRequest req, HttpServletResponse resp) {
+		final AsyncContext ac = req.startAsync();
+		executor.execute(new Runnable() {
+			@Override
+			public void run() {
+				req.setAttribute("_position", 0);
+				req.setAttribute("_read", 0);
+				ac.dispatch();
+			}
+		});
+	}
+
+	private void continueResponding(final HttpServletRequest req, final HttpServletResponse resp) {
+		final AsyncContext ac = req.startAsync();
+		int read = (Integer) req.getAttribute("_read");
+		int position = (Integer) req.getAttribute("_position");
+		if (read > 0) {
+			// return current part
+			byte[] buf = new byte[read];
+			Arrays.fill(buf, (byte) 0x42);
+			try {
+				resp.getOutputStream().write(buf);
+				resp.flushBuffer();
+				position += read;
+				req.setAttribute("_position", position);
+			} catch (IOException e) {
+				resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+				ac.complete();
+			}
+		}
+		if (position == SIZE) {
+			ac.complete();
+		} else {
+			// schedule reading next part
+			final int _position = position;
+			executor.execute(new Runnable() {
+				@Override
+				public void run() {
+					// read next part/chunk
+					int _read = Math.min(PART, SIZE - _position);
+					try {
+						Thread.sleep(100);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+					req.setAttribute("_read", _read);
+					ac.dispatch();
+				}
+			});
+		}
+	}
+
+}

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/ContextSelectionHostValve.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/ContextSelectionHostValve.java
@@ -36,6 +36,7 @@ public class ContextSelectionHostValve extends ValveBase {
 	Mapper mapper;
 
 	public ContextSelectionHostValve(Valve standardHostValve, Mapper mapper) {
+		super(true);
 		this.standardHostValve = standardHostValve;
 		this.mapper = mapper;
 	}

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/ServiceValve.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/ServiceValve.java
@@ -33,6 +33,7 @@ public class ServiceValve extends ValveBase {
 	private HttpContext httpContext;
 
 	public ServiceValve(HttpContext httpContext) {
+		super(true);
 		this.httpContext = httpContext;
 	}
 


### PR DESCRIPTION
This PR copies the AsyncServletIntegration test from Jetty (including the servlet) and marks the asynchronous test servlets and the valves contained in pax-web-tomcat as supporting asynchronous requests