### PR TITLE
[PAXWEB-1142] wildcard registration for error servlet does not work w…

### DIFF
--- a/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/AbstractWhiteboardR6IntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/AbstractWhiteboardR6IntegrationTest.java
@@ -105,18 +105,13 @@ public abstract class AbstractWhiteboardR6IntegrationTest extends ITestBase {
 
 	protected abstract String getErrorMessage(int statusCode);
 
-	protected Dictionary<String, Object> getRegistrationProperties() {
+	@Test
+	public void testErrorServlet() throws Exception {
 		Dictionary<String, Object> properties = new Hashtable<>();
 		properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ERROR_PAGE, new String[] {
 				"404", "442", "5xx",
 				"java.io.IOException"
 		});
-		return properties;
-	}
-	
-	@Test
-	public void testErrorServlet() throws Exception {
-		Dictionary<String, Object> properties = getRegistrationProperties();
 
 		ServiceRegistration<Servlet> errorServletReg = ErrorServlet.register(bundleContext, properties);
 		ServiceRegistration<Servlet> brokenServletReg = BrokenServlet.register(bundleContext);

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardR6IntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WhiteboardR6IntegrationTest.java
@@ -15,10 +15,8 @@
  */
 package org.ops4j.pax.web.itest.tomcat;
 
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.Map;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -27,7 +25,6 @@ import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.web.itest.common.AbstractWhiteboardR6IntegrationTest;
-import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 @RunWith(PaxExam.class)
 public class WhiteboardR6IntegrationTest extends AbstractWhiteboardR6IntegrationTest {
@@ -48,21 +45,4 @@ public class WhiteboardR6IntegrationTest extends AbstractWhiteboardR6Integration
     protected String getErrorMessage(int statusCode) {
         return ERROR_MESSAGES.get(statusCode);
     }
-
-    @Override
-    /*
-     * This is a workaround for PAXWEB-1142
-     *
-     * The error page registration should actually be for "5xx" instead of "500", "502"
-     *
-     */
-	protected Dictionary<String, Object> getRegistrationProperties() {
-		Dictionary<String, Object> properties = new Hashtable<>();
-		properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ERROR_PAGE, new String[] {
-				"404", "442", "500", "502",
-				"java.io.IOException"
-		});
-		return properties;
-	}
-
 }

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -686,18 +686,35 @@ class TomcatServerWrapper implements ServerWrapper {
 			throw new AddErrorPageException(
 					"cannot retrieve the associated context: " + model);
 		}
-		final ErrorPage errorPage = createErrorPage(model);
-		context.addErrorPage(errorPage);
+		// for Nxx codes, we have to loop
+		// Tomcat doesn't support error code range handlers, but
+		// in the end - it's just a io.undertow.servlet.core.ErrorPages.errorCodeLocations map of code -> location
+		if ("4xx".equals(model.getError())) {
+			for (int c = 400; c < 500; c++) {
+				final ErrorPage errorPage = createErrorPage(model, c);
+				context.addErrorPage(errorPage);
+			}
+		} else if ("5xx".equals(model.getError())) {
+			for (int c = 500; c < 600; c++) {
+				final ErrorPage errorPage = createErrorPage(model, c);
+				context.addErrorPage(errorPage);
+			}
+		} else {
+			final ErrorPage errorPage = createErrorPage(model, null);
+			context.addErrorPage(errorPage);
+		}
 	}
 
-	private ErrorPage createErrorPage(final ErrorPageModel model) {
+	private ErrorPage createErrorPage(final ErrorPageModel model, Integer errorCode) {
 		NullArgumentException.validateNotNull(model, "model");
 		NullArgumentException.validateNotNull(model.getLocation(),
 				"model#location");
 		NullArgumentException.validateNotNull(model.getError(), "model#error");
 		final ErrorPage errorPage = new ErrorPage();
 		errorPage.setLocation(model.getLocation());
-		final Integer errorCode = parseErrorCode(model.getError());
+		if (errorCode == null) {
+			errorCode = parseErrorCode(model.getError());
+		}
 		if (errorCode != null) {
 			errorPage.setErrorCode(errorCode);
 		} else {
@@ -723,11 +740,23 @@ class TomcatServerWrapper implements ServerWrapper {
 			throw new RemoveErrorPageException(
 					"cannot retrieve the associated context: " + model);
 		}
-
-		LOG.info("remove error page");
-		final ErrorPage errorPage = createErrorPage(model);
-		context.removeErrorPage(errorPage);
-
+		// for Nxx codes, we have to loop
+		// Tomcat doesn't support error code range handlers, but
+		// in the end - it's just a io.undertow.servlet.core.ErrorPages.errorCodeLocations map of code -> location
+		if ("4xx".equals(model.getError())) {
+			for (int c = 400; c < 500; c++) {
+				final ErrorPage errorPage = createErrorPage(model, c);
+				context.removeErrorPage(errorPage);
+			}
+		} else if ("5xx".equals(model.getError())) {
+			for (int c = 500; c < 600; c++) {
+				final ErrorPage errorPage = createErrorPage(model, c);
+				context.removeErrorPage(errorPage);
+			}
+		} else {
+			final ErrorPage errorPage = createErrorPage(model, null);
+			context.removeErrorPage(errorPage);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
…ith Tomcat container

Actually this was easier than I thought: Just like undertow tomcat does not support 4xx and 5xx error pages out of the box, so models with this create 100 error pages (as they do with pax-web-undertow)