### PR TITLE
[PAXWEB-1095] don't ignore JSP test on other containers than Jetty

### DIFF
--- a/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/AbstractJspSimpleIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/AbstractJspSimpleIntegrationTest.java
@@ -17,7 +17,6 @@ package org.ops4j.pax.web.itest.common;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.ops4j.pax.web.itest.base.VersionUtil;
 import org.ops4j.pax.web.itest.base.client.HttpTestClientFactory;
@@ -53,7 +52,6 @@ public abstract class AbstractJspSimpleIntegrationTest extends ITestBase {
 
 
 	@Test
-	@Ignore
 	public void testSimpleJspWithCookies() throws Exception {
 
 		Thread.sleep(2000); //let the web.xml parser finish his job

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/JspSimpleIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/JspSimpleIntegrationTest.java
@@ -15,6 +15,8 @@
  */
 package org.ops4j.pax.web.itest.jetty;
 
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
@@ -30,5 +32,11 @@ public class JspSimpleIntegrationTest extends AbstractJspSimpleIntegrationTest {
     @Configuration
     public static Option[] configure() {
         return configureJetty();
+    }
+
+    @Test
+    @Ignore
+    public void testSimpleJspWithCookies() throws Exception {
+        super.testSimpleJspWithCookies();
     }
 }


### PR DESCRIPTION
This change actually only re-enables one integration test for other containers than jetty and ignores it for jetty only. I still think that the issue with the integration test should be fixed for jetty.