### PR TITLE
[PAXWEB-1159] Upgrade commons-collections

### DIFF
--- a/pax-web-features/src/main/resources/features.xml
+++ b/pax-web-features/src/main/resources/features.xml
@@ -225,7 +225,7 @@
         <bundle dependency="true">mvn:javax.validation/validation-api/${dependency.validation-api.version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr303-api-1.0.0/${servicemix.specs.version}</bundle>
         <bundle dependency="true">mvn:commons-beanutils/commons-beanutils/1.8.3</bundle>
-        <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.1</bundle>
+        <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
         <bundle dependency="true">mvn:commons-codec/commons-codec/1.8</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-digester/1.8_4</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.bundles/commons-discovery/0.4_1</bundle>

--- a/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/TestConfiguration.java
+++ b/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/TestConfiguration.java
@@ -121,7 +121,7 @@ public class TestConfiguration {
 				mavenBundle("commons-io", "commons-io").version("1.4"),
 				mavenBundle("commons-codec", "commons-codec").version("1.10"),
 				mavenBundle("commons-beanutils", "commons-beanutils").version("1.8.3"),
-				mavenBundle("commons-collections", "commons-collections").version("3.2.1"),
+				mavenBundle("commons-collections", "commons-collections").version("3.2.2"),
 				mavenBundle("commons-digester", "commons-digester").version("1.8.1"),
 				mavenBundle("org.apache.commons", "commons-lang3").version("3.4")
 		);

--- a/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/AbstractWarJsfCdiIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/AbstractWarJsfCdiIntegrationTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractWarJsfCdiIntegrationTest extends ITestBase {
                 mavenBundle("javax.validation", "validation-api").version("1.1.0.Final"),
                 mavenBundle("commons-codec", "commons-codec").version("1.10"),
                 mavenBundle("commons-beanutils", "commons-beanutils").version("1.8.3"),
-                mavenBundle("commons-collections", "commons-collections").version("3.2.1"),
+                mavenBundle("commons-collections", "commons-collections").version("3.2.2"),
                 mavenBundle("org.apache.servicemix.bundles", "org.apache.servicemix.bundles.commons-digester").version("1.8_4"),
 
                 // JSF

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/CdiIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/CdiIntegrationTest.java
@@ -63,7 +63,7 @@ public class CdiIntegrationTest extends ITestBase {
                 mavenBundle("commons-io", "commons-io").version("1.4"),
                 mavenBundle("commons-codec", "commons-codec").version("1.10"),
                 mavenBundle("commons-beanutils", "commons-beanutils").version("1.8.3"),
-                mavenBundle("commons-collections", "commons-collections").version("3.2.1"),
+                mavenBundle("commons-collections", "commons-collections").version("3.2.2"),
                 mavenBundle("commons-digester", "commons-digester").version("1.8.1"),
                 mavenBundle("org.apache.commons", "commons-lang3").version("3.4"),
                 // JSF

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency.commons-beanutils.version>1.9.2</dependency.commons-beanutils.version>
 		<dependency.commons-codec.version>1.8</dependency.commons-codec.version>
 		<dependency.commons-collection3.version>3.2.2</dependency.commons-collection3.version>
-		<dependency.commons-collection.version>4.0</dependency.commons-collection.version>
+		<dependency.commons-collection.version>4.1</dependency.commons-collection.version>
 		<dependency.commons-lang.version>3.3.2</dependency.commons-lang.version>
 		<dependency.commons-logging.version>1.1.1</dependency.commons-logging.version>
 		<dependency.felix.framework.version>5.6.10</dependency.felix.framework.version>


### PR DESCRIPTION
This patch upgrades commons-collections to 3.2.2 and 4.1; this upgrade
had already been done partially, it is completed here. Upgrading to
3.2.2 and 4.1 fixes COLLECTIONS-580, aka CVE-2015-4852, the
deserialization-related RCE.

Release notes:
* https://commons.apache.org/proper/commons-collections/release_3_2_2.html
* https://commons.apache.org/proper/commons-collections/release_4_1.html

Signed-off-by: Stephen Kitt <skitt@redhat.com>