### PR TITLE
[PAXWEB-1163] WebAppParser uses wrong default values for multipart cfg

### DIFF
--- a/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/parser/WebAppParser.java
+++ b/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/parser/WebAppParser.java
@@ -610,13 +610,13 @@ public class WebAppParser {
 			}
 			long maxFileSize;
 			if (multipartConfig.getMaxFileSize() == null) {
-				maxFileSize = 0;
+				maxFileSize = -1L;
 			} else {
 				maxFileSize = multipartConfig.getMaxFileSize();
 			}
 			long maxRequestSize;
 			if (multipartConfig.getMaxRequestSize() == null) {
-				maxRequestSize = 0;
+				maxRequestSize = -1L;
 			} else {
 				maxRequestSize = multipartConfig.getMaxRequestSize();
 			}


### PR DESCRIPTION
The maxFileSize and maxRequestSize parameter must actually default to -1 (infinite) instead of 0 (which really means 0) as in the default constructor of javax.servlet.MultipartConfigElement