### PR TITLE
[PAXWEB-1164] Upgrade to ASM 6.2 and Jetty 9.4.10.v20180503

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 	</developers>
 
 	<properties>
-		<dependency.asm.version>6.0</dependency.asm.version>
+		<dependency.asm.version>6.2</dependency.asm.version>
 		<dependency.atinject.version>1.0</dependency.atinject.version>
 		<dependency.base.version>1.5.0</dependency.base.version>
 		<dependency.bndlib.version>2.4.0</dependency.bndlib.version>
@@ -117,7 +117,7 @@
 		<dependency.jdt.groupId>org.eclipse.jdt.core.compiler</dependency.jdt.groupId>
 		<dependency.jdt.artifactId>ecj</dependency.jdt.artifactId>
 		<dependency.jdt.version>4.5.1</dependency.jdt.version>
-		<dependency.jetty.version>9.4.6.v20170531</dependency.jetty.version>
+		<dependency.jetty.version>9.4.10.v20180503</dependency.jetty.version>
 		<dependency.jsr303.version>1.8.0</dependency.jsr303.version>
 		<dependency.jsr305.version>1.3.9_1</dependency.jsr305.version>
 		<dependency.jstl.version>1.2</dependency.jstl.version>


### PR DESCRIPTION
This PR upgrades to ASM 6.2 and Jetty 9.4.10.v20180503 on Pax Web 7.1.x