### PR TITLE
[PAXWEB-1176] Update to Tomcat 8.5.32

### DIFF
--- a/pax-web-jsp/src/main/java/org/apache/jasper/JspCompilationContext.java
+++ b/pax-web-jsp/src/main/java/org/apache/jasper/JspCompilationContext.java
@@ -253,19 +253,13 @@ public class JspCompilationContext {
     protected Compiler createCompiler(String className) {
         Compiler compiler = null;
         try {
-            compiler = (Compiler) Class.forName(className).newInstance();
-        } catch (InstantiationException e) {
-            log.warn(Localizer.getMessage("jsp.error.compiler"), e);
-        } catch (IllegalAccessException e) {
-            log.warn(Localizer.getMessage("jsp.error.compiler"), e);
-        } catch (NoClassDefFoundError e) {
+            compiler = (Compiler) Class.forName(className).getConstructor().newInstance();
+        } catch (NoClassDefFoundError | ClassNotFoundException e) {
             if (log.isDebugEnabled()) {
                 log.debug(Localizer.getMessage("jsp.error.compiler"), e);
             }
-        } catch (ClassNotFoundException e) {
-            if (log.isDebugEnabled()) {
-                log.debug(Localizer.getMessage("jsp.error.compiler"), e);
-            }
+        } catch (ReflectiveOperationException e) {
+            log.warn(Localizer.getMessage("jsp.error.compiler"), e);
         }
         return compiler;
     }

--- a/pax-web-jsp/src/main/java/org/ops4j/pax/web/jsp/TldParser.java
+++ b/pax-web-jsp/src/main/java/org/ops4j/pax/web/jsp/TldParser.java
@@ -38,69 +38,64 @@ import org.xml.sax.SAXException;
  * Parses a Tag Library Descriptor.
  */
 public class TldParser {
-	private static final Log LOG = LogFactory.getLog(TldParser.class);
-	private final Digester digester;
+    private final Log log = LogFactory.getLog(TldParser.class); // must not be static
+    private final Digester digester;
 
-	public TldParser(boolean namespaceAware, boolean validation,
-					 boolean blockExternal) {
-		this(namespaceAware, validation, new TldRuleSet(), blockExternal);
-	}
+    public TldParser(boolean namespaceAware, boolean validation,
+            boolean blockExternal) {
+        this(namespaceAware, validation, new TldRuleSet(), blockExternal);
+    }
 
-	public TldParser(boolean namespaceAware, boolean validation,
-					 RuleSet ruleSet, boolean blockExternal) {
-		digester = DigesterFactory.newDigester(validation, namespaceAware,
-				ruleSet, blockExternal);
-	}
+    public TldParser(boolean namespaceAware, boolean validation, RuleSet ruleSet,
+            boolean blockExternal) {
+        digester = DigesterFactory.newDigester(
+                validation, namespaceAware, ruleSet, blockExternal);
+    }
 
-	public TaglibXml parse(TldResourcePath path) throws IOException,
-			SAXException {
-		ClassLoader original;
-		if (Constants.IS_SECURITY_ENABLED) {
-			PrivilegedGetTccl pa = new PrivilegedGetTccl();
-			original = AccessController.doPrivileged(pa);
-		} else {
-			original = Thread.currentThread().getContextClassLoader();
-		}
-		try (InputStream is = path.openStream()) {
-			if (Constants.IS_SECURITY_ENABLED) {
-				PrivilegedSetTccl pa = new PrivilegedSetTccl(
-						TldParser.class.getClassLoader());
-				AccessController.doPrivileged(pa);
-			} else {
-				Thread.currentThread().setContextClassLoader(
-						TldParser.class.getClassLoader());
-			}
-			XmlErrorHandler handler = new XmlErrorHandler();
-			digester.setErrorHandler(handler);
+    public TaglibXml parse(TldResourcePath path) throws IOException, SAXException {
+        ClassLoader original;
+        if (Constants.IS_SECURITY_ENABLED) {
+            PrivilegedGetTccl pa = new PrivilegedGetTccl();
+            original = AccessController.doPrivileged(pa);
+        } else {
+            original = Thread.currentThread().getContextClassLoader();
+        }
+        try (InputStream is = path.openStream()) {
+            if (Constants.IS_SECURITY_ENABLED) {
+                PrivilegedSetTccl pa = new PrivilegedSetTccl(TldParser.class.getClassLoader());
+                AccessController.doPrivileged(pa);
+            } else {
+                Thread.currentThread().setContextClassLoader(TldParser.class.getClassLoader());
+            }
+            XmlErrorHandler handler = new XmlErrorHandler();
+            digester.setErrorHandler(handler);
 
-			TaglibXml taglibXml = new TaglibXml();
-			digester.push(taglibXml);
+            TaglibXml taglibXml = new TaglibXml();
+            digester.push(taglibXml);
 
-			InputSource source = new InputSource(path.toExternalForm());
-			source.setByteStream(is);
-			digester.parse(source);
-			if (!handler.getWarnings().isEmpty()
-					|| !handler.getErrors().isEmpty()) {
-				handler.logFindings(LOG, source.getSystemId());
-				if (!handler.getErrors().isEmpty()) {
-					// throw the first to indicate there was a error during
-					// processing
-					throw handler.getErrors().iterator().next();
-				}
-			}
-			return taglibXml;
-		} finally {
-			digester.reset();
-			if (Constants.IS_SECURITY_ENABLED) {
-				PrivilegedSetTccl pa = new PrivilegedSetTccl(original);
-				AccessController.doPrivileged(pa);
-			} else {
-				Thread.currentThread().setContextClassLoader(original);
-			}
-		}
-	}
+            InputSource source = new InputSource(path.toExternalForm());
+            source.setByteStream(is);
+            digester.parse(source);
+            if (!handler.getWarnings().isEmpty() || !handler.getErrors().isEmpty()) {
+                handler.logFindings(log, source.getSystemId());
+                if (!handler.getErrors().isEmpty()) {
+                    // throw the first to indicate there was a error during processing
+                    throw handler.getErrors().iterator().next();
+                }
+            }
+            return taglibXml;
+        } finally {
+            digester.reset();
+            if (Constants.IS_SECURITY_ENABLED) {
+                PrivilegedSetTccl pa = new PrivilegedSetTccl(original);
+                AccessController.doPrivileged(pa);
+            } else {
+                Thread.currentThread().setContextClassLoader(original);
+            }
+        }
+    }
 
-	public void setClassLoader(ClassLoader classLoader) {
-		digester.setClassLoader(classLoader);
-	}
+    public void setClassLoader(ClassLoader classLoader) {
+        digester.setClassLoader(classLoader);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 		<dependency.slf4j>1.7.12</dependency.slf4j>
 		<dependency.scr.version>2.0.12</dependency.scr.version>
 		<dependency.swissbox.version>1.8.2</dependency.swissbox.version>
-		<dependency.tomcat.version>8.5.20</dependency.tomcat.version>
+		<dependency.tomcat.version>8.5.32</dependency.tomcat.version>
 		<dependency.xbean.version>4.6</dependency.xbean.version>
 		<dependency.xnio-api.version>3.3.8.Final</dependency.xnio-api.version>
 		<dependency.xnio.version>3.3.8.Final</dependency.xnio.version>
@@ -141,7 +141,7 @@
 		<dependency.pax-keycloak.version>0.2.0</dependency.pax-keycloak.version>
 		<version.pax-exam>4.9.2</version.pax-exam>
 
-		<tipi.tomcat.version>8.5.20.1</tipi.tomcat.version>
+		<tipi.tomcat.version>8.5.32.1</tipi.tomcat.version>
 		<jsf-myfaces.version>2.2.12</jsf-myfaces.version>
 
 		<dependency.junit.version>4.11</dependency.junit.version>

--- a/samples/helloworld-jsp/pom.xml
+++ b/samples/helloworld-jsp/pom.xml
@@ -58,7 +58,7 @@
 							javax.servlet.http,
 							javax.servlet.jsp,
 							javax.servlet.jsp.tagext,
-							!org.apache.tomcat
+							org.apache.tomcat; resolution:=optional
 						</Import-Package>
 						<Export-Package>!*</Export-Package>
 						<Private-Package>
@@ -94,12 +94,12 @@
 					<packageName>org.apache.jsp</packageName>
 					<defaultSourcesDirectory>${project.basedir}/src/main/resources</defaultSourcesDirectory>
 				</configuration>
-				<!-- Use the Tomcat 6 JSP compiler -->
+				<!-- Use the Tomcat 8 JSP compiler -->
 				<dependencies>
 					<dependency>
 						<groupId>org.jasig.mojo.jspc</groupId>
-						<artifactId>jspc-compiler-tomcat6</artifactId>
-						<version>2.0.0</version>
+						<artifactId>jspc-compiler-tomcat8</artifactId>
+						<version>2.0.2</version>
 						<exclusions>
 							<exclusion>
 								<groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
This PR contains 3 kinds of changes:
1. The version update in the parent pom (which is quite obvious).
2. The changes in pax-web-jsp. These classes are slightly modified copies of the original from the tomcat-JSP bundle. I took the classes from the new tomcat base version as a new base and applied the changes.
3. The change in the helloworld-jsp bundle. Here I added an optional import to org.apache.tomcat.

Inside this test bundle, classes are generated from the JSP and these classes are packaged into the resulting jar. These generated classes have an Attribute of the type org.apache.tomcat.InstanceManager

When the (Catalina) context of this bundle is started with the Tomcat container (even before any JSP processing is happening), Tomcat tries to scan servlets for annotations. When doing this for attritbute annotations, it turns out that the class loader of the helloworld-jsp bundle cannot resolve the class of an attribute contained in a class from that bundle. With that error the context initialization will stop, so Jasper will not get properly intitialized. As a consequence some JSP functions do not work properly and one test fails.

I think the helloworld-jsp bundle is just wrong. If it contains a class referencing package org.apache.tomcat it should also import that package.

I don't know why this works with older tomcat versions or other containers. Maybe they don't scan of attribute annotations or they initialize Jasper earlier, but I actually think that the issue is with the test bundle not with pax-web-tomcat.