### PR TITLE
[PAXWEB-1180] Add ability to specify a default authMethod and realmName for Jetty Container

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/service/WebContainerConstants.java
@@ -138,7 +138,8 @@ public interface WebContainerConstants {
 
 	String PROPERTY_VIRTUAL_HOST_LIST = "org.ops4j.pax.web.default.virtualhosts";
 	String PROPERTY_CONNECTOR_LIST = "org.ops4j.pax.web.default.connectors";
-
+    String PROPERTY_DEFAULT_AUTHMETHOD = "org.ops4j.pax.web.default.authmethod";
+    String PROPERTY_DEFAULT_REALMNAME = "org.ops4j.pax.web.default.realmname";
 
 	String PROPERTY_MAX_THREADS = "org.ops4j.pax.web.server.maxThreads";
 

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServer.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServer.java
@@ -118,6 +118,14 @@ public interface JettyServer {
 
 	URL getServerConfigURL();
 
+	void setDefaultAuthMethod(String defaultAuthMethod);
+
+	String getDefaultAuthMethod() ;
+
+	void setDefaultRealmName(String defaultRealmName);
+
+	String getDefaultRealmName() ;
+
 	void addServletContainerInitializer(ContainerInitializerModel model);
 
 	Connector[] getConnectors();

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerImpl.java
@@ -954,6 +954,26 @@ class JettyServerImpl implements JettyServer {
 	}
 
 	@Override
+	public void setDefaultAuthMethod(String defaultAuthMethod) {
+		server.setDefaultAuthMethod(defaultAuthMethod);
+	}
+
+	@Override
+	public String getDefaultAuthMethod() {
+		return server.getDefaultAuthMethod();
+	}
+
+	@Override
+	public void setDefaultRealmName(String defaultRealmName) {
+		server.setDefaultRealmName(defaultRealmName);
+	}
+
+	@Override
+	public String getDefaultRealmName() {
+		return server.getDefaultRealmName();
+	}
+
+	@Override
 	public JettyServerWrapper getServer() {
 		return server;
 	}

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -118,6 +118,9 @@ class JettyServerWrapper extends Server {
 
 	private URL serverConfigURL;
 
+	private String defaultAuthMethod;
+	private String defaultRealmName;
+
 	private Boolean sessionCookieHttpOnly;
 
 	private Boolean sessionCookieSecure;
@@ -329,6 +332,12 @@ class JettyServerWrapper extends Server {
 				modelSessionUrl, modelSessionCookieHttpOnly, modelSessionSecure, workerName, lazyLoad, storeDirectory,
 				maxAge);
 
+		if(this.defaultAuthMethod != null && model.getAuthMethod() == null){
+            model.setAuthMethod(this.defaultAuthMethod);
+        }
+        if(this.defaultRealmName != null && model.getRealmName() == null){
+            model.setRealmName(this.defaultRealmName);
+        }
 		if (model.getRealmName() != null && model.getAuthMethod() != null) {
 			configureSecurity(context, model.getRealmName(), model.getAuthMethod(), model.getFormLoginPage(),
 					model.getFormErrorPage());
@@ -618,5 +627,20 @@ class JettyServerWrapper extends Server {
 
 	public void setServerConfigURL(URL serverConfigURL) {
 		this.serverConfigURL = serverConfigURL;
+	}
+
+	public String getDefaultAuthMethod(){
+	    return defaultAuthMethod;
+    }
+
+	public void setDefaultAuthMethod(String defaultAuthMethod) {
+		this.defaultAuthMethod = defaultAuthMethod;
+	}
+	public String getDefaultRealmName() {
+		return defaultRealmName;
+	}
+
+	public void setDefaultRealmName(String defaultRealmName) {
+		this.defaultRealmName = defaultRealmName;
 	}
 }

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ServerControllerImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/ServerControllerImpl.java
@@ -459,6 +459,8 @@ class ServerControllerImpl implements ServerController {
 			// Fix for PAXWEB-193
 			jettyServer.setServerConfigDir(configuration.getConfigurationDir());
 			jettyServer.setServerConfigURL(configuration.getConfigurationURL());
+			jettyServer.setDefaultAuthMethod(configuration.getDefaultAuthMethod());
+			jettyServer.setDefaultRealmName(configuration.getDefaultRealmName());
 			jettyServer.configureContext(attributes,
 					configuration.getSessionTimeout(),
 					configuration.getSessionCookie(),

--- a/pax-web-jetty/src/test/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapperTest.java
+++ b/pax-web-jetty/src/test/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapperTest.java
@@ -50,6 +50,8 @@ import org.osgi.service.http.HttpContext;
 public class JettyServerWrapperTest {
 	private static final String KNOWN_CONTEXT_NAME = "TestContext";
 	private static final String BUNDLE_SYMBOLIC_NAME = "BundleSymbolicName";
+	private static final String DEFAULT_AUTH_METHOD = "DDF";
+	private static final String DEFAULT_REALM_NAME = "Karaf";
 	private static final int NUMBER_OF_CONCURRENT_EXECUTIONS = 2;
 	private static final int REPETITIONS_OF_MULTI_THREADED_TEST = 1000;
 	@Mock
@@ -69,6 +71,10 @@ public class JettyServerWrapperTest {
 		when(contextModelMock.getContextName()).thenReturn(KNOWN_CONTEXT_NAME);
 		when(contextModelMock.getHttpContext()).thenReturn(httpContextMock);
 		when(contextModelMock.getBundle()).thenReturn(bundleMock);
+		doCallRealMethod().when(contextModelMock).getRealmName();
+		doCallRealMethod().when(contextModelMock).getAuthMethod();
+		doCallRealMethod().when(contextModelMock).setRealmName(anyString());
+		doCallRealMethod().when(contextModelMock).setAuthMethod(anyString());
 		when(bundleMock.getHeaders()).thenReturn(
 				new Hashtable<>());
 		when(bundleMock.getSymbolicName()).thenReturn(BUNDLE_SYMBOLIC_NAME);
@@ -215,4 +221,36 @@ public class JettyServerWrapperTest {
 		}
 	}
 
+	@Test
+	public void testDefaultAuthMethod()
+			throws Exception {
+		final JettyServerWrapper jettyServerWrapperUnderTest = new JettyServerWrapper(
+				serverModelMock, new QueuedThreadPool());
+		try {
+			assertNull(contextModelMock.getAuthMethod());
+			jettyServerWrapperUnderTest.setDefaultAuthMethod(DEFAULT_AUTH_METHOD);
+			jettyServerWrapperUnderTest.start();
+			HttpServiceContext context = jettyServerWrapperUnderTest.getOrCreateContext(contextModelMock);
+			context.start();
+			assertTrue(DEFAULT_AUTH_METHOD.equals(contextModelMock.getAuthMethod()));
+		} finally {
+			jettyServerWrapperUnderTest.stop();
+		}
+	}
+	@Test
+	public void testDefaultRealmName()
+			throws Exception {
+		final JettyServerWrapper jettyServerWrapperUnderTest = new JettyServerWrapper(
+				serverModelMock, new QueuedThreadPool());
+		try {
+			assertNull(contextModelMock.getRealmName());
+			jettyServerWrapperUnderTest.setDefaultRealmName(DEFAULT_REALM_NAME);
+			jettyServerWrapperUnderTest.start();
+			HttpServiceContext context = jettyServerWrapperUnderTest.getOrCreateContext(contextModelMock);
+			context.start();
+			assertTrue(DEFAULT_REALM_NAME.equals(contextModelMock.getRealmName()));
+		} finally {
+			jettyServerWrapperUnderTest.stop();
+		}
+	}
 }

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/Activator.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/Activator.java
@@ -74,6 +74,8 @@ import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_ALGOR
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_ENABLED;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_PREFIX;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_SUFFIX;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_DEFAULT_AUTHMETHOD;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_DEFAULT_REALMNAME;
 
 import java.io.File;
 import java.util.Dictionary;
@@ -519,6 +521,10 @@ public class Activator implements BundleActivator {
 		setProperty(toPropagate, PROPERTY_WORKER_NAME, configuration.getWorkerName());
 		setProperty(toPropagate, PROPERTY_LISTENING_ADDRESSES,
 				configuration.getListeningAddresses());
+		setProperty(toPropagate, PROPERTY_DEFAULT_AUTHMETHOD,
+				configuration.getDefaultAuthMethod());
+		setProperty(toPropagate, PROPERTY_DEFAULT_REALMNAME,
+				configuration.getDefaultRealmName());
 
 		// then replace ports
 		setProperty(toPropagate, PROPERTY_HTTP_PORT, httpPort);

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/ConfigurationImpl.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/ConfigurationImpl.java
@@ -86,6 +86,8 @@ import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_ALGOR
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_ENABLED;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_PREFIX;
 import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_ENC_SUFFIX;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_DEFAULT_AUTHMETHOD;
+import static org.ops4j.pax.web.service.WebContainerConstants.PROPERTY_DEFAULT_REALMNAME;
 
 import java.io.File;
 import java.net.URI;
@@ -903,6 +905,12 @@ public class ConfigurationImpl extends PropertyStore implements Configuration, C
         return getResolvedStringProperty(PROPERTY_ENC_SUFFIX);
     }
     
+	@Override
+	public String getDefaultAuthMethod() {return getResolvedStringProperty(PROPERTY_DEFAULT_AUTHMETHOD); }
+
+	@Override
+	public String getDefaultRealmName() {return getResolvedStringProperty(PROPERTY_DEFAULT_REALMNAME); }
+
     private String decryptPassword(String password) {
         if (this.encryptor == null && isEncEnabled()) {
             String masterPassword;

--- a/pax-web-runtime/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/pax-web-runtime/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -94,6 +94,8 @@ limitations under the License.
         <AD name="Algorithm for Encrypted password" id="org.ops4j.pax.web.enc.algorithm"     type="String" default="PBEWithMD5AndDES" />
         <AD name="Prefix for Encrypted password" id="org.ops4j.pax.web.enc.prefix"     type="String" default="ENC(" />
         <AD name="Suffix for Encrypted password" id="org.ops4j.pax.web.enc.suffix"     type="String" default=")" /> 
+        <AD name="Default Auth" id="org.ops4j.pax.web.default.authmethod" required="false" type="String" default=""/>
+        <AD name="Default Realm" id="org.ops4j.pax.web.default.realmname" required="false" type="String" default=""/>
 	</OCD>
 	<Designate pid="org.ops4j.pax.web">
         <Object ocdref="org.ops4j.pax.web"/>

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
@@ -249,4 +249,8 @@ public interface Configuration {
 	String getEncPrefix();
 	
 	String getEncSuffix();
+
+	String getDefaultAuthMethod();
+
+	String getDefaultRealmName();
 }


### PR DESCRIPTION
I'm personally going to need to port this back to 7.2.3 for our project but that'll stay on the fork.