### PR TITLE
[PAXWEB-1180] Fix interface to have a default for versioning

### DIFF
--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/Configuration.java
@@ -250,7 +250,23 @@ public interface Configuration {
 	
 	String getEncSuffix();
 
-	String getDefaultAuthMethod();
+	/**
+	 * The default implementation will be removed on next major release - 8.0.0
+	 * No default auth method with be used if implementation is not provided.
+	 *
+	 * @return the default auth method, null if not implemented
+	 */
+	default String getDefaultAuthMethod(){
+		return null;
+	}
 
-	String getDefaultRealmName();
+	/**
+	 * The default implementation will be removed on next major release - 8.0.0
+	 * No default realm name with be used if implementation is not provided.
+	 *
+	 * @return the default realm name, null if not implemented
+	 */
+	default String getDefaultRealmName(){
+		return null;
+	}
 }


### PR DESCRIPTION
Address comments mentioned in: https://groups.google.com/forum/#!topic/ops4j/4XkeOKL7L6k

Provide default methods for the Configuration interface to work with semantic versioning.