### PR TITLE
circleci: extend no output timeout for tomcat tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
         - v1-dep-
     - run:
         command: mvn -B -o -P tomcat integration-test verify
-        no_output_timeout: 30m
+        no_output_timeout: 29m
     - run:
         name: Save test results
         command: |


### PR DESCRIPTION
fix the tomcat integration tests in circleci