### PR TITLE
Fix a typo when activating the service

### DIFF
--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/Activator.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/Activator.java
@@ -185,7 +185,7 @@ public class Activator implements BundleActivator {
 			eventServiceTracker.open();
 			context.registerService(ServletListener.class, adminHandler,
 					null);
-			LOG.info("EventAdmin support enabled, servlet events will be postet to topics.");
+			LOG.info("EventAdmin support enabled, servlet events will be posted to topics.");
 		} else {
 			LOG.info("EventAdmin support is not available, no servlet events will be posted!");
 		}


### PR DESCRIPTION
Fixes a small typo I found when working on a different issue.