### PR TITLE
Prevents the overwriting default handler warning

### DIFF
--- a/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/Context.java
+++ b/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/Context.java
@@ -130,6 +130,15 @@ public class Context implements LifeCycle, HttpHandler, ResourceManager {
 	public Context(IdentityManager identityManager, ContextAwarePathHandler path, ContextModel contextModel) {
 		this.identityManager = identityManager;
 		this.path = path;
+
+		/*
+		 * Explicitly replaces the default context handler set by default on the ContextAwarePathHandler. By doing it
+		 * this way, it avoids a warning message issued by the PathMatcher stating that the default handler is being
+		 * replaced
+ 		 */
+
+		path.safeReplace(this);
+
 		this.contextModel = contextModel;
 
 		ClassLoader classLoader = contextModel.getClassLoader();

--- a/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/ContextAwarePathHandler.java
+++ b/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/ContextAwarePathHandler.java
@@ -170,6 +170,10 @@ public class ContextAwarePathHandler extends PathHandler {
 		return this;
 	}
 
+	public synchronized void safeReplace(HttpHandler handler) {
+		pathMatcher.safeReplace(handler);
+	}
+
 	public HttpHandler getDefaultHandler() {
 		return pathMatcher.getDefaultHandler();
 	}

--- a/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/PathMatcher.java
+++ b/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/PathMatcher.java
@@ -94,6 +94,21 @@ public class PathMatcher<T> {
 	}
 
 	/**
+	 * Explicitly replace of the default handler. It is meant for situations where replacing
+	 * it is desired by the calling code and prevents the warning message that appears when
+	 * the replacement happens implicitly (ie.: via addPrefixPath)
+	 * @param handler The handler that will replace the current default handler
+	 */
+	public synchronized void safeReplace(final T handler) {
+		if (this.defaultHandler != null) {
+			LOG.debug("Explicitly overwriting existing default context {} with a new one {}",
+					this.defaultHandler, handler);
+		}
+
+		this.defaultHandler = handler;
+	}
+
+	/**
 	 * Adds a path prefix and a handler for that path. If the path does not start
 	 * with a / then one will be prepended.
 	 * <p>


### PR DESCRIPTION
Introduces a way for the calling code to explicitly replace the default handler for situations where such behavior is desired.