### PR TITLE
Fix incorrect number of parameters for log messages

### DIFF
--- a/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/parser/WebFilterAnnotationConfigurer.java
+++ b/pax-web-extender-war/src/main/java/org/ops4j/pax/web/extender/war/internal/parser/WebFilterAnnotationConfigurer.java
@@ -43,7 +43,7 @@ public class WebFilterAnnotationConfigurer extends
 		Class<?> clazz = loadClass();
 
 		if (clazz == null) {
-			log.warn("Class %s wasn't loaded", this.className);
+			log.warn("Class {} wasn't loaded", this.className);
 			return;
 		}
 

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/HttpServiceContext.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/HttpServiceContext.java
@@ -368,7 +368,7 @@ class HttpServiceContext extends ServletContextHandler {
 				if (ex instanceof RuntimeException) {
 					throw (RuntimeException) ex;
 				}
-				LOG.error("Ignored exception during listener registration", e);
+				LOG.error("Ignored exception during listener registration: {}", ex.getMessage(), e);
 			}
 
 		} finally {

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -584,7 +584,7 @@ class JettyServerWrapper extends Server {
 		if (sessionHandler != null) {
 			if (minutes != null) {
 				sessionHandler.setMaxInactiveInterval(minutes * 60);
-				LOG.debug("Session timeout set to {} minutes for context [{]]", minutes, context);
+				LOG.debug("Session timeout set to {} minutes for context [{}]", minutes, context);
 			}
 			if (cookie != null && !"none".equals(cookie)) {
 				sessionHandler.getSessionCookieConfig().setName(cookie);

--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStarted.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/HttpServiceStarted.java
@@ -286,7 +286,7 @@ class HttpServiceStarted implements StoppableHttpService {
 								  final HttpContext httpContext) throws NamespaceException {
 		synchronized (lock) {
 			final ContextModel contextModel = getOrCreateContext(httpContext);
-			LOG.debug("Register resources (alias={}). Using context [" + contextModel + "]");
+			LOG.debug("Register resources (alias={}). Using context [{}]", alias, contextModel);
 
 			// PAXWEB-1085, OSGi Enterprise R6 140.6 "Registering Resources", JavaEE Servlet spec "12.2 Specification of Mappings"
 			// "A string beginning with a ‘ / ’ character and ending with a ‘ /* ’ suffix is used for path mapping."

--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatServerWrapper.java
@@ -332,7 +332,7 @@ class TomcatServerWrapper implements ServerWrapper {
 				server.stop();
 				server.destroy();
 			} catch (final Throwable e) {
-				LOG.error("LifecycleException caught {}", e);
+				LOG.error("LifecycleException caught {}", e.getMessage(), e);
 			}
 			//CHECKSTYLE:ON
 		}
@@ -765,7 +765,7 @@ class TomcatServerWrapper implements ServerWrapper {
 	@Override
 	public Servlet createResourceServlet(final ContextModel contextModel,
 										 final String alias, final String name) {
-		LOG.debug("createResourceServlet( contextModel: {}, alias: {}, name: {})");
+		LOG.debug("createResourceServlet( contextModel: {}, alias: {}, name: {})", contextModel, alias, name);
 		final Context context = findOrCreateContext(contextModel);
 		return new TomcatResourceServlet(contextModel.getHttpContext(),
 				contextModel.getContextName(), alias, name, context);
@@ -1142,10 +1142,10 @@ class TomcatServerWrapper implements ServerWrapper {
             if (errorHandler.getWarnings().size() > 0 ||
                     errorHandler.getErrors().size() > 0) {
                 for (SAXParseException e : errorHandler.getWarnings()) {
-                    LOG.warn("Warning in XML processing", e.getMessage(), source);
+                    LOG.warn("Warning in XML processing: {}", e.getMessage(), source);
                 }
                 for (SAXParseException e : errorHandler.getErrors()) {
-                    LOG.warn("Error in XML processing", e.getMessage(), source);
+                    LOG.warn("Error in XML processing: {}", e.getMessage(), source);
                 }
             }
             if (LOG.isDebugEnabled()) {

--- a/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/Context.java
+++ b/pax-web-undertow/src/main/java/org/ops4j/pax/web/service/undertow/internal/Context.java
@@ -351,7 +351,8 @@ public class Context implements LifeCycle, HttpHandler, ResourceManager {
 					&& webContextPath.equals(reg.getReference().getProperty(WebContainerConstants.PROPERTY_SERVLETCONTEXT_PATH)))
 					.findFirst();
 			if (serviceReg.isPresent()) {
-				LOG.debug("Unregistered ServletContext with ServletContext Name: ", serviceReg.get().getReference().getProperty(WebContainerConstants.PROPERTY_SERVLETCONTEXT_NAME));
+				LOG.debug("Unregistered ServletContext with ServletContext Name: {}",
+						serviceReg.get().getReference().getProperty(WebContainerConstants.PROPERTY_SERVLETCONTEXT_NAME));
 
 					serviceReg.get().unregister();
 			}


### PR DESCRIPTION
This fixes a couple of instances where the number of parameters for the log message did not match the number of parameters given to the log method.

Also fixes a few occurrences of incorrect log formatting.