### PR TITLE
Stop using deprecated Jetty SslContextFactory constructor

### DIFF
--- a/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/client/JettyTestClient.java
+++ b/pax-web-itest/pax-web-itest-base/src/main/java/org/ops4j/pax/web/itest/base/client/JettyTestClient.java
@@ -218,7 +218,7 @@ class JettyTestClient implements HttpTestClient {
 	public String executeTest() throws Exception {
 		final HttpClient httpClient;
 		if (keystoreLocationURL != null) {
-			SslContextFactory sslContextFactory = new SslContextFactory(true);
+			SslContextFactory sslContextFactory = new SslContextFactory.Client(true);
 			sslContextFactory.setKeyStorePath(keystoreLocationURL.toString());
 			sslContextFactory.setKeyStorePassword(keystorePassword);
 			sslContextFactory.setKeyManagerPassword(keyManagerPassword);

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/WebContainerSpdyIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/WebContainerSpdyIntegrationTest.java
@@ -146,7 +146,7 @@ public class WebContainerSpdyIntegrationTest extends ITestBase {
 	@Ignore("org.eclipse.jetty.io.NegotiatingClientConnectionFactory not found by org.eclipse.jetty.alpn.client")
 	public void testWebContextPath() throws Exception {
 	    HTTP2Client client = new HTTP2Client();
-        SslContextFactory sslContextFactory = new SslContextFactory(true);
+        SslContextFactory sslContextFactory = new SslContextFactory.Client(true);
         client.addBean(sslContextFactory);
         client.start();
         

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactoryImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactoryImpl.java
@@ -354,7 +354,7 @@ class JettyFactoryImpl implements JettyFactory {
 												 String sslProvider) {
 
 		// SSL Context Factory for HTTPS and SPDY
-		SslContextFactory sslContextFactory = new SslContextFactory();
+		SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
 
 		if (null != sslProvider && !"".equals(sslProvider.trim())) {
 			sslContextFactory.setProvider(sslProvider);


### PR DESCRIPTION
The main reason behind this PR is to fix a problem with client authentication - https://github.com/eclipse/jetty.project/issues/3554