### PR TITLE
Pax Web 7.3.3 - fix JSP support

### DIFF
--- a/pax-web-jsp/pom.xml
+++ b/pax-web-jsp/pom.xml
@@ -112,7 +112,7 @@
 							org.apache.tomcat.util.descriptor.tld;resolution:=optional; -split-package:="merge-last",
 							org.apache.tomcat.util.security;resolution:=optional; -split-package:="merge-last",
 							org.apache.catalina.loader;resolution:=optional,
-							org.apache.juli.logging,
+							!org.apache.juli.logging,
 							!org.eclipse.jdt.core.index,
 							!org.eclipse.jdt.core.util,
 							!com.sun.tools.javac,

--- a/pax-web-jsp/src/main/java/org/apache/jasper/JspCompilationContext.java
+++ b/pax-web-jsp/src/main/java/org/apache/jasper/JspCompilationContext.java
@@ -149,6 +149,15 @@ public class JspCompilationContext {
 
     /* ==================== Methods to override ==================== */
 
+    /** ---------- Add getters and setters for field basePackageName required by Tomcat 9 ---- */
+    public String getBasePackageName() {
+		return basePackageName;
+	}
+    public void setBasePackageName(String basePackageName) {
+		this.basePackageName = basePackageName;
+	}
+    
+    
     /** ---------- Class path and loader ---------- */
 
     /**


### PR DESCRIPTION
Pax web 7.3.3 embeds org.apache.juli.logging but it also declares the same package in the list of imported packages (without exporting it). This makes the bundle impossible to resolve and adding an additional bundle that exports the same package leads to a runtime error.

Additionally, Pax Web JSP 7.3.3 depends on Tomcat 9 Jasper, and JSP compilation did not work anymore because the patched JspCompilationContext included in Pax Web JSP does not provide getter and setter methods for field basePackageName. Getter and setter have been introduced in Tomcat 9 and are used by Jasper.