### PR TITLE
[PAXWEB-1027] Activate Websocket test

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/utils/ServletContainerInitializerScanner.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/utils/ServletContainerInitializerScanner.java
@@ -67,9 +67,9 @@ public class ServletContainerInitializerScanner {
 			try {
 				InputStream is = u.openStream();
 				BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-				// only the first line is read, it contains the name of the
-				// class.
-				String className = reader.readLine();
+				// only the first non-empty and non-comment line is read, it contains
+				// the name of the class.
+				String className = parseServiceConfig(reader);
 				log.info("will add {} to ServletContainerInitializers", className);
 
 				if (className.endsWith("JasperInitializer")) {
@@ -137,4 +137,24 @@ public class ServletContainerInitializerScanner {
 			}
 		}
 	}
+
+	private String parseServiceConfig(BufferedReader r) throws IOException  {
+		String ln;
+		do {
+			ln = r.readLine();
+			if (ln == null) {
+				// no more lines, abort
+				return null;
+			}
+			// remove comments
+			int ci = ln.indexOf('#');
+			if (ci >= 0) {
+				ln = ln.substring(0, ci);
+			}
+			ln = ln.trim();
+			// if the line is empty read the next one
+		} while (ln.isEmpty());
+		return ln;
+	}
+
 }

--- a/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/ITestBase.java
+++ b/pax-web-itest/pax-web-itest-common/src/main/java/org/ops4j/pax/web/itest/common/ITestBase.java
@@ -109,6 +109,10 @@ public abstract class ITestBase extends AbstractControlledTestBase {
 	public static Option[] configureWebSocketJetty() {
 		return combine(
 				configureJetty(),
+				// needed for websocket-client
+				mavenBundle().groupId("org.eclipse.jetty")
+						.artifactId("jetty-client").version(asInProject()),
+
 				mavenBundle().groupId("org.eclipse.jetty.websocket")
 						.artifactId("websocket-server").version(asInProject()),
 						
@@ -131,6 +135,10 @@ public abstract class ITestBase extends AbstractControlledTestBase {
 						.artifactId("javax-websocket-client-impl").version(asInProject()),
 						
 				mavenBundle().groupId("org.glassfish").artifactId("javax.json")
+						.versionAsInProject(),
+
+				mavenBundle().groupId("javax.websocket")
+						.artifactId("javax.websocket-api")
 						.versionAsInProject(),
 
 				mavenBundle().groupId("javax.json")
@@ -161,11 +169,11 @@ public abstract class ITestBase extends AbstractControlledTestBase {
 				mavenBundle().groupId("org.apache.servicemix.specs").artifactId("org.apache.servicemix.specs.jaxb-api-2.2").version(asInProject()),
 				mavenBundle().groupId("org.apache.geronimo.specs").artifactId("geronimo-jaxws_2.2_spec").version(asInProject()),
 				mavenBundle().groupId("org.apache.geronimo.specs").artifactId("geronimo-jaxrpc_1.1_spec").version(asInProject()),
-				/*
+
 				mavenBundle().groupId("javax.websocket")
 						.artifactId("javax.websocket-api")
 						.versionAsInProject(),
-				*/
+
 				mavenBundle().groupId("org.apache.geronimo.specs").artifactId("geronimo-jta_1.1_spec").versionAsInProject(),
 				mavenBundle().groupId("org.apache.servicemix.specs").artifactId("org.apache.servicemix.specs.jsr303-api-1.0.0").version(asInProject()),
 				mavenBundle().groupId("org.apache.geronimo.specs").artifactId("geronimo-activation_1.1_spec").version(asInProject()),

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/pom.xml
@@ -351,6 +351,12 @@
 		<dependency>
 			<groupId>org.eclipse.jetty.websocket</groupId>
 			<artifactId>javax-websocket-client-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.websocket</groupId>
+                    <artifactId>javax.websocket-client-api</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 
 
@@ -438,7 +444,6 @@
 		<dependency>
 			<groupId>javax.websocket</groupId>
 			<artifactId>javax.websocket-api</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.json</groupId>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/WebSocketIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-jetty/src/test/java/org/ops4j/pax/web/itest/jetty/WebSocketIntegrationTest.java
@@ -18,6 +18,9 @@ package org.ops4j.pax.web.itest.jetty;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.OptionUtils.combine;
 
+import javax.websocket.WebSocketContainer;
+
+import org.eclipse.jetty.websocket.jsr356.JettyClientContainerProvider;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
@@ -40,7 +43,17 @@ public class WebSocketIntegrationTest extends AbstractWebSocketIntegrationTest {
 						.artifactId("websocket-jsr356")
 						.type("war")
 						.version(VersionUtil.getProjectVersion()),
-				mavenBundle().groupId("javax.json")
-						.artifactId("javax.json-api").versionAsInProject());
+				mavenBundle().groupId("org.glassfish")
+						.artifactId("javax.json").versionAsInProject());
+	}
+
+	protected WebSocketContainer getWebSocketContainer() {
+		ClassLoader orig = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(JettyClientContainerProvider.class.getClassLoader());
+			return JettyClientContainerProvider.getWebSocketContainer();
+		} finally {
+			Thread.currentThread().setContextClassLoader(orig);
+		}
 	}
 }

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/pom.xml
@@ -528,6 +528,12 @@
         <!-- test framework -->
         <!-- Rules for using within tests -->
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.cedarsoft.commons</groupId>
             <artifactId>test-utils</artifactId>
             <version>6.0.1</version>

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WebSocketIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WebSocketIntegrationTest.java
@@ -21,8 +21,6 @@ import static org.ops4j.pax.exam.OptionUtils.combine;
 import javax.websocket.WebSocketContainer;
 
 import org.apache.tomcat.websocket.WsContainerProvider;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
@@ -47,12 +45,6 @@ public class WebSocketIntegrationTest extends AbstractWebSocketIntegrationTest {
 						.version(VersionUtil.getProjectVersion()),
 				mavenBundle().groupId("org.glassfish")
 						.artifactId("javax.json").versionAsInProject());
-	}
-
-	@Test
-	@Ignore (value = "PAXWEB-1027")
-	public void testWebsocket() throws Exception {
-		super.testWebsocket();
 	}
 
 	protected WebSocketContainer getWebSocketContainer() {

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WebSocketIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-tomcat/src/test/java/org/ops4j/pax/web/itest/tomcat/WebSocketIntegrationTest.java
@@ -18,6 +18,11 @@ package org.ops4j.pax.web.itest.tomcat;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.OptionUtils.combine;
 
+import javax.websocket.WebSocketContainer;
+
+import org.apache.tomcat.websocket.WsContainerProvider;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
@@ -40,7 +45,23 @@ public class WebSocketIntegrationTest extends AbstractWebSocketIntegrationTest {
 						.artifactId("websocket-jsr356")
 						.type("war")
 						.version(VersionUtil.getProjectVersion()),
-				mavenBundle().groupId("javax.json")
-						.artifactId("javax.json-api").versionAsInProject());
+				mavenBundle().groupId("org.glassfish")
+						.artifactId("javax.json").versionAsInProject());
+	}
+
+	@Test
+	@Ignore (value = "PAXWEB-1027")
+	public void testWebsocket() throws Exception {
+		super.testWebsocket();
+	}
+
+	protected WebSocketContainer getWebSocketContainer() {
+		ClassLoader orig = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(WsContainerProvider.class.getClassLoader());
+			return WsContainerProvider.getWebSocketContainer();
+		} finally {
+			Thread.currentThread().setContextClassLoader(orig);
+		}
 	}
 }

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/java/org/ops4j/pax/web/itest/undertow/WebSocketIntegrationTest.java
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-undertow/src/test/java/org/ops4j/pax/web/itest/undertow/WebSocketIntegrationTest.java
@@ -16,14 +16,21 @@
 package org.ops4j.pax.web.itest.undertow;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.OptionUtils.combine;
 
+import javax.websocket.WebSocketContainer;
+
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.web.itest.base.VersionUtil;
 import org.ops4j.pax.web.itest.common.AbstractWebSocketIntegrationTest;
+
+import io.undertow.websockets.jsr.UndertowContainerProvider;
 
 
 /**
@@ -36,11 +43,29 @@ public class WebSocketIntegrationTest extends AbstractWebSocketIntegrationTest {
 	public static Option[] configure() {
 		return combine(
 				configureWebSocketUndertow(),
+                systemProperty("org.ops4j.pax.web.samples.websocket.register.programatically")
+                    .value("true"),
 				mavenBundle().groupId("org.ops4j.pax.web.samples")
 						.artifactId("websocket-jsr356")
 						.type("war")
 						.version(VersionUtil.getProjectVersion()),
-				mavenBundle().groupId("javax.json")
-						.artifactId("javax.json-api").versionAsInProject());
+				mavenBundle().groupId("org.glassfish")
+						.artifactId("javax.json").versionAsInProject());
+	}
+
+	@Test
+	@Ignore (value = "PAXWEB-1027")
+	public void testWebsocket() throws Exception {
+		super.testWebsocket();
+	}
+
+	protected WebSocketContainer getWebSocketContainer() {
+		ClassLoader orig = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(UndertowContainerProvider.class.getClassLoader());
+			return UndertowContainerProvider.getWebSocketContainer();
+		} finally {
+			Thread.currentThread().setContextClassLoader(orig);
+		}
 	}
 }

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -76,6 +76,8 @@
 							javax.servlet.descriptor; version="[2.5.0,4.0)",
 							javax.servlet.jsp.*;version="[2.2,2.3)",
 							javax.servlet.*; version="[2.5.0,4.0)",
+                            javax.websocket,
+                            javax.websocket.server,
 							javax.xml.parsers,
 							org.osgi.framework; version="[1.0.0,2.0.0)",
 							org.osgi.service.http; version="[1.0.0,2.0.0)",

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -201,6 +201,11 @@
 			<artifactId>org.ops4j.pax.tipi.tomcat-embed-websocket</artifactId>
 			<scope>provided</scope>
 		</dependency>
+        <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
 		<!-- Provided dependencies (not transitive) -->
 		<dependency>

--- a/pax-web-tomcat/src/main/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/pax-web-tomcat/src/main/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.tomcat.websocket.server.WsSci

--- a/pax-web-tomcat/src/main/resources/META-INF/services/javax.websocket.ContainerProvider
+++ b/pax-web-tomcat/src/main/resources/META-INF/services/javax.websocket.ContainerProvider
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.tomcat.websocket.WsContainerProvider

--- a/pax-web-tomcat/src/main/resources/META-INF/services/javax.websocket.server.ServerEndpointConfig$Configurator
+++ b/pax-web-tomcat/src/main/resources/META-INF/services/javax.websocket.server.ServerEndpointConfig$Configurator
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.tomcat.websocket.server.DefaultServerEndpointConfigurator

--- a/samples/websocket-jsr356/pom.xml
+++ b/samples/websocket-jsr356/pom.xml
@@ -56,8 +56,8 @@
 						<Web-ContextPath>websocket</Web-ContextPath>
 						<Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
 						<Import-Package>
-							*, 
-							javax.servlet
+                            javax.servlet,
+							*
 						</Import-Package>
 						<Bundle-Classpath>
                             WEB-INF/classes


### PR DESCRIPTION
This pull request contains two commits:

The first one does not contain any productive coding, it only re-enables the websocket integration test for Jetty. On Tomcat and Undertow the tests are still disabled because they fail.

The second commit adds websocket support for the Tomcat container and enables the test for it.