### PR TITLE
Use try-with-resources in DefaultPropertyResolver

### DIFF
--- a/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/DefaultPropertyResolver.java
+++ b/pax-web-runtime/src/main/java/org/ops4j/pax/web/service/internal/DefaultPropertyResolver.java
@@ -53,9 +53,8 @@ class DefaultPropertyResolver extends DictionaryPropertyResolver {
 	private static Dictionary<String, String> getDefaltProperties() {
 		Dictionary<String, String> properties = new Hashtable<>();
 
-		InputStream stream = DefaultPropertyResolver.class.getClassLoader()
-				.getResourceAsStream("OSGI-INF/metatype/metatype.xml");
-		try {
+		try (InputStream stream = DefaultPropertyResolver.class.getClassLoader()
+				.getResourceAsStream("OSGI-INF/metatype/metatype.xml")) {
 			Element rootElement = getRootElement(stream);
 			Element[] children = getChildren(rootElement, "AD");
 			for (Element element : children) {


### PR DESCRIPTION
A trivial fix to use try-with-resources to make sure the InputStream is closed.