### PR TITLE
[javadoc] TomcatResourceServlet copyRange does not close streams

### DIFF
--- a/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatResourceServlet.java
+++ b/pax-web-tomcat/src/main/java/org/ops4j/pax/web/service/tomcat/internal/TomcatResourceServlet.java
@@ -374,8 +374,7 @@ public class TomcatResourceServlet extends HttpServlet {
 
 	/**
 	 * Copy the contents of the specified input stream to the specified output
-	 * stream, and ensure that both streams are closed before returning (even in
-	 * the face of an exception).
+	 * stream.
 	 *
 	 * @param istream The input stream to read from
 	 * @param ostream The output stream to write to


### PR DESCRIPTION
The JavaDoc describes that it closes both streams, but it closes none. Simply remove the sentence from JavaDoc.