### PR TITLE
Fix/ssl context factory

### DIFF
--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactoryImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyFactoryImpl.java
@@ -345,7 +345,7 @@ class JettyFactoryImpl implements JettyFactory {
 												 Boolean checkForwaredHeaders) {
 
 		// SSL Context Factory for HTTPS and SPDY
-		SslContextFactory sslContextFactory = new SslContextFactory();
+		SslContextFactory sslContextFactory = new SslContextFactory.Server();
 		sslContextFactory.setKeyStorePath(sslKeystore);
 		sslContextFactory.setKeyStorePassword(sslKeystorePassword);
 		sslContextFactory.setKeyManagerPassword(sslKeyPassword);


### PR DESCRIPTION
Remove call to deprecated jetty SslContextFactory constructor

As of jetty-9.4.23, this constructor may lead to an exception when keys are checked. New jetty code throws exception when SslContextFactory constructor is used instead of SslContextFactory.Server. This is the new jetty exception that is thrown: `

    /**
     * @deprecated use {@link SslContextFactory.Server#newSniX509ExtendedKeyManager(X509ExtendedKeyManager)} instead
     */
    @Deprecated
    protected X509ExtendedKeyManager newSniX509ExtendedKeyManager(X509ExtendedKeyManager keyManager)
    {
        throw new UnsupportedOperationException("X509ExtendedKeyManager only supported on Server");
    }`