### PR TITLE
PAXWEB-1274 support jetty 9.4.34

### DIFF
--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerImpl.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerImpl.java
@@ -316,14 +316,14 @@ class JettyServerImpl implements JettyServer {
 					((org.eclipse.jetty.util.component.LifeCycle) server.getThreadPool()).start();
 				}
 
-				// Fixfor PAXWEB-725
-				ClassLoader classLoader = context.getClassLoader();
-				List<Bundle> bundles = ((ResourceDelegatingBundleClassLoader) classLoader).getBundles();
-				BundleClassLoader parentClassLoader
-						= new BundleClassLoader(bundle);
-				ResourceDelegatingBundleClassLoader containerSpecificClassLoader = new ResourceDelegatingBundleClassLoader(bundles, parentClassLoader);
-				context.setClassLoader(containerSpecificClassLoader);
 				if (!context.isStarted()) {
+					// Fixfor PAXWEB-725
+					ClassLoader classLoader = context.getClassLoader();
+					List<Bundle> bundles = ((ResourceDelegatingBundleClassLoader) classLoader).getBundles();
+					BundleClassLoader parentClassLoader
+							= new BundleClassLoader(bundle);
+					ResourceDelegatingBundleClassLoader containerSpecificClassLoader = new ResourceDelegatingBundleClassLoader(bundles, parentClassLoader);
+					context.setClassLoader(containerSpecificClassLoader);
 					context.start();
 				}
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 		<dependency.jdt.groupId>org.eclipse.jdt.core.compiler</dependency.jdt.groupId>
 		<dependency.jdt.artifactId>ecj</dependency.jdt.artifactId>
 		<dependency.jdt.version>4.5.1</dependency.jdt.version>
-		<dependency.jetty.version>9.4.31.v20200723</dependency.jetty.version>
+		<dependency.jetty.version>9.4.34.v20201102</dependency.jetty.version>
 		<dependency.jsr303.version>1.8.0</dependency.jsr303.version>
 		<dependency.jsr305.version>1.3.9_1</dependency.jsr305.version>
 		<dependency.jstl.version>1.2</dependency.jstl.version>


### PR DESCRIPTION
@ANierbeck concerns a fix for PAXWEB-1274. Please review. As mentioned on the ticket, when upgrading to the new jetty version integration tests registering filters already failed. As such tests are included that cover this change.