### PR TITLE
Added repackaged Keycloak 21 libraries 21.0.0.

### DIFF
--- a/pax-web-features/pom.xml
+++ b/pax-web-features/pom.xml
@@ -104,21 +104,25 @@
 								<feature>pax-web-http-jetty</feature>
 <!--								<feature>pax-web-jetty-keycloak18</feature>-->
 								<feature>pax-web-jetty-keycloak20</feature>
+								<feature>pax-web-jetty-keycloak21</feature>
 								<feature>pax-web-tomcat</feature>
 								<feature>pax-web-tomcat-websockets</feature>
 								<feature>pax-web-http-tomcat</feature>
 <!--								<feature>pax-web-tomcat-keycloak18</feature>-->
 								<feature>pax-web-tomcat-keycloak20</feature>
+								<feature>pax-web-tomcat-keycloak21</feature>
 								<feature>pax-web-undertow</feature>
 								<feature>pax-web-undertow-websockets</feature>
 <!--								<feature>pax-web-undertow-keycloak18</feature>-->
 								<feature>pax-web-undertow-keycloak20</feature>
+								<feature>pax-web-undertow-keycloak21</feature>
 								<feature>pax-web-http-undertow</feature>
 								<feature>pax-web-jsp</feature>
 								<feature>pax-web-whiteboard</feature>
 								<feature>pax-web-war</feature>
 								<feature>pax-web-karaf</feature>
 								<feature>keycloak20-adapter-core</feature>
+								<feature>keycloak21-adapter-core</feature>
 							</features>
 							<verifyTransitive>false</verifyTransitive>
 							<ignoreMissingConditions>true</ignoreMissingConditions>

--- a/pax-web-features/src/main/resources/features.xml
+++ b/pax-web-features/src/main/resources/features.xml
@@ -205,6 +205,14 @@ javax.servlet.context.tempdir = ${karaf.data}/pax-web/tmp
 		<bundle start="false" start-level="25">mvn:org.ops4j.pax.web/pax-web-jetty-keycloak20/${project.version}</bundle>
 	</feature>
 
+	<feature name="pax-web-jetty-keycloak21" description="Keycloak 21.x+ Jetty bundles" version="${project.version}">
+		<!-- This feature doesn't require any external feature repository -->
+		<feature>keycloak21-adapter-core</feature>
+		<feature>pax-web-http-jetty</feature>
+
+		<bundle start="false" start-level="25">mvn:org.ops4j.pax.web/pax-web-jetty-keycloak21/${project.version}</bundle>
+	</feature>
+
 	<feature name="pax-web-tomcat" description="Tomcat 9 bundles" version="${dependency.org.apache.tomcat}">
 		<details>
 			Tomcat libraries are repackaged in pax-web-tomcat bundle based on tomcat-embed-core
@@ -306,6 +314,14 @@ javax.servlet.context.tempdir = ${karaf.data}/pax-web/tmp
 		<bundle start="false" start-level="25">mvn:org.ops4j.pax.web/pax-web-tomcat-keycloak20/${project.version}</bundle>
 	</feature>
 
+	<feature name="pax-web-tomcat-keycloak21" description="Keycloak 21.x+ Tomcat bundles" version="${project.version}">
+		<!-- This feature doesn't require any external feature repository -->
+		<feature>keycloak21-adapter-core</feature>
+		<feature>pax-web-tomcat</feature>
+
+		<bundle start="false" start-level="25">mvn:org.ops4j.pax.web/pax-web-tomcat-keycloak21/${project.version}</bundle>
+	</feature>
+
 	<feature name="pax-web-undertow" description="Undertow 2 bundles" version="${dependency.io.undertow}">
 		<details>
 			Undertow libraries are proper OSGi bundles, but pax-web-undertow exports required Wildfly packages
@@ -404,6 +420,14 @@ javax.servlet.context.tempdir = ${karaf.data}/pax-web/tmp
 		<bundle start="false" start-level="25">mvn:org.ops4j.pax.web/pax-web-undertow-keycloak20/${project.version}</bundle>
 	</feature>
 
+	<feature name="pax-web-undertow-keycloak21" description="Keycloak 21.x+ Undertow bundles" version="${project.version}">
+		<!-- This feature doesn't require any external feature repository -->
+		<feature>keycloak21-adapter-core</feature>
+		<feature>pax-web-undertow</feature>
+
+		<bundle start="false" start-level="25">mvn:org.ops4j.pax.web/pax-web-undertow-keycloak21/${project.version}</bundle>
+	</feature>
+
 	<!-- JSP suport -->
 
 	<feature name="pax-web-jsp" version="${project.version}">
@@ -472,6 +496,36 @@ javax.servlet.context.tempdir = ${karaf.data}/pax-web/tmp
 
 		<bundle>mvn:org.ops4j.pax.web/keycloak20-common/${project.version}</bundle>
 		<bundle>mvn:org.ops4j.pax.web/keycloak20-osgi-adapter/${project.version}</bundle>
+
+		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${dependency.org.apache.httpcomponents.core4}</bundle>
+		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${dependency.org.apache.httpcomponents.client4}</bundle>
+
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${dependency.com.fasterxml.jackson.core}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${dependency.com.fasterxml.jackson.core}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${dependency.com.fasterxml.jackson.core.databind}</bundle>
+
+		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk18on/${dependency.org.bouncycastle}</bundle>
+		<bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk18on/${dependency.org.bouncycastle}</bundle>
+		<bundle dependency="true">mvn:org.bouncycastle/bcutil-jdk18on/${dependency.org.bouncycastle}</bundle>
+	</feature>
+
+	<feature name="keycloak21-adapter-core" description="Migration of removed Keyloak feature to Pax Web" version="${project.version}">
+		<details>This feature replaces a feature that was available in Keycloak 18 and earlier</details>
+
+		<!--
+			These bundles were part of keycloak-adapter-core feature in Keycloak 18, but
+			 - there are new dependencies (keycloak-crypto-default)
+			 - there's SPI requirement (https://github.com/keycloak/keycloak/issues/9287), but we don't want SPI-Fly
+			 - we can control packages better after repackaging (OSGi is not easy...)
+		-->
+		<!--		<bundle>mvn:org.keycloak/keycloak-common/${dependency.org.keycloak21}</bundle>-->
+		<!--		<bundle>mvn:org.keycloak/keycloak-core/${dependency.org.keycloak21}</bundle>-->
+		<!--		<bundle>mvn:org.keycloak/keycloak-authz-client/${dependency.org.keycloak21}</bundle>-->
+		<!--		<bundle>mvn:org.keycloak/keycloak-adapter-spi/${dependency.org.keycloak21}</bundle>-->
+		<!--		<bundle>mvn:org.keycloak/keycloak-adapter-core/${dependency.org.keycloak21}</bundle>-->
+
+		<bundle>mvn:org.ops4j.pax.web/keycloak21-common/${project.version}</bundle>
+		<bundle>mvn:org.ops4j.pax.web/keycloak21-osgi-adapter/${project.version}</bundle>
 
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${dependency.org.apache.httpcomponents.core4}</bundle>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${dependency.org.apache.httpcomponents.client4}</bundle>

--- a/pax-web-keycloak21/keycloak21-common/pom.xml
+++ b/pax-web-keycloak21/keycloak21-common/pom.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2023 OPS4J.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>pax-web-keycloak21</artifactId>
+		<version>9.0.6-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.ops4j.pax.web</groupId>
+	<artifactId>keycloak21-common</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>OPS4J Pax Web - Keycloak 21.x+ support - common</name>
+
+	<description>
+		This module repackages fundamental Keycloak bundles ensuring correct set of exported/imported packages.
+		The reason is that Keycloak drops (not maintains) OSGi integration, so Pax Web can be a new home for
+		OSGified versions.
+	</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-Description>Repackage of Keycloak common packages</Bundle-Description>
+						<Private-Package>
+							org.keycloak.crypto.def;-split-package:=merge-first,
+							org.keycloak.*
+						</Private-Package>
+						<Export-Package>
+							<!--
+								org.keycloak/keycloak-common
+								depends on:
+								 - com.sun.activation/jakarta.activation
+							-->
+							org.keycloak.common;version="${dependency.org.keycloak21}",
+							org.keycloak.common.constants;version="${dependency.org.keycloak21}",
+							org.keycloak.common.crypto;version="${dependency.org.keycloak21}",
+							org.keycloak.common.enums;version="${dependency.org.keycloak21}",
+							org.keycloak.common.util;version="${dependency.org.keycloak21}",
+							org.keycloak.common.util.reflections;version="${dependency.org.keycloak21}",
+							<!--
+								org.keycloak/keycloak-core
+								depends on:
+								 - com.fasterxml.jackson.core/jackson-core
+								 - com.fasterxml.jackson.core/jackson-databind
+							-->
+							org.keycloak;version="${dependency.org.keycloak21}",
+							org.keycloak.constants;version="${dependency.org.keycloak21}",
+							org.keycloak.crypto;version="${dependency.org.keycloak21}",
+							org.keycloak.enums;version="${dependency.org.keycloak21}",
+							org.keycloak.exceptions;version="${dependency.org.keycloak21}",
+							org.keycloak.jose;version="${dependency.org.keycloak21}",
+							org.keycloak.jose.jwe;version="${dependency.org.keycloak21}",
+							org.keycloak.jose.jwe.alg;version="${dependency.org.keycloak21}",
+							org.keycloak.jose.jwe.enc;version="${dependency.org.keycloak21}",
+							org.keycloak.jose.jwk;version="${dependency.org.keycloak21}",
+							org.keycloak.jose.jws;version="${dependency.org.keycloak21}",
+							org.keycloak.jose.jws.crypto;version="${dependency.org.keycloak21}",
+							org.keycloak.json;version="${dependency.org.keycloak21}",
+							org.keycloak.protocol;version="${dependency.org.keycloak21}",
+							org.keycloak.protocol.oidc;version="${dependency.org.keycloak21}",
+							org.keycloak.protocol.oidc.representations;version="${dependency.org.keycloak21}",
+							org.keycloak.representations;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.account;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.adapters;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.adapters.action;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.adapters.config;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.docker;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.idm;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.idm.authorization;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.info;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.oidc;version="${dependency.org.keycloak21}",
+							org.keycloak.representations.provider;version="${dependency.org.keycloak21}",
+							org.keycloak.util;version="${dependency.org.keycloak21}",
+							<!--
+								org.keycloak/keycloak-authz-client
+								depends (1st level) on:
+								 - org.apache.httpcomponents/httpclient
+								 - org.jboss.logging/jboss-logging
+							-->
+							org.keycloak.authorization.client;version="${dependency.org.keycloak21}",
+							org.keycloak.authorization.client.representation;version="${dependency.org.keycloak21}",
+							org.keycloak.authorization.client.resource;version="${dependency.org.keycloak21}",
+							org.keycloak.authorization.client.util;version="${dependency.org.keycloak21}",
+							<!--
+								org.keycloak/keycloak-adapter-spi
+							-->
+							org.keycloak.adapters.spi;version="${dependency.org.keycloak21}",
+							<!--
+								org.keycloak/keycloak-adapter-core
+								depends on:
+								 - org.keycloak/keycloak-crypto-default
+								    - org.bouncycastle/bcpkix-jdk15on
+								    - org.bouncycastle/bcprov-jdk15on
+								    - org.keycloak/keycloak-server-spi
+								    - org.keycloak/keycloak-server-spi-private
+								       - com.github.ua-parser/uap-java
+								          - org.apache.commons/commons-collections4
+								          - org.yaml/snakeyaml
+								       - org.apache.httpcomponents/httpclient
+								the point is that we don't actually need the server-side stuff, only an ability
+								to get org.keycloak.crypto.def.DefaultCryptoProvider (org.keycloak.common.crypto.CryptoProvider)
+								Fortunately the server-spi[-private] deps are only needed by
+								org.keycloak.crypto.def.BCOCSPProvider
+							-->
+							org.keycloak.adapters;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.authentication;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.authorization;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.authorization.cip;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.authorization.util;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.jaas;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.rotation;version="${dependency.org.keycloak21}",
+							<!--
+								org.keycloak/keycloak-crypto-default
+							-->
+							org.keycloak.crypto.def;version="${dependency.org.keycloak21}";-split-package:=merge-first
+						</Export-Package>
+						<Import-Package>
+							com.fasterxml.jackson.annotation;version="[2.14,3)",
+							com.fasterxml.jackson.core.io;version="[2.14,3)",
+							com.fasterxml.jackson.core.type;version="[2.14,3)",
+							com.fasterxml.jackson.core.util;version="[2.14,3)",
+							com.fasterxml.jackson.core;version="[2.14,3)",
+							com.fasterxml.jackson.databind.annotation;version="[2.14,3)",
+							com.fasterxml.jackson.databind.node;version="[2.14,3)",
+							com.fasterxml.jackson.databind;version="[2.14,3)",
+							com.sun.security.jgss;resolution:=optional,
+							javax.activation;version="[1.2,2)";resolution:=optional,
+							javax.crypto,
+							javax.crypto.spec,
+							javax.net.ssl,
+							javax.security.auth;resolution:=optional,
+							javax.security.auth.kerberos;resolution:=optional,
+							javax.security.auth.login;resolution:=optional,
+							javax.security.cert,
+							javax.security.auth.callback,
+							javax.security.auth.spi,
+							org.apache.http.auth;version="[4.5,5)",
+							org.apache.http.client.config;version="[4.5,5)",
+							org.apache.http.client.entity;version="[4.5,5)",
+							org.apache.http.client.methods;version="[4.5,5)",
+							org.apache.http.client;version="[4.5,5)",
+							org.apache.http.config;version="[4.4,5)",
+							org.apache.http.conn.scheme;version="[4.5,5)",
+							org.apache.http.conn.socket;version="[4.5,5)",
+							org.apache.http.conn.ssl;version="[4.5,5)",
+							org.apache.http.conn;version="[4.5,5)",
+							org.apache.http.cookie;version="[4.5,5)",
+							org.apache.http.entity;version="[4.4,5)",
+							org.apache.http.impl.auth;version="[4.5,5)",
+							org.apache.http.impl.client;version="[4.5,5)",
+							org.apache.http.impl.conn;version="[4.5,5)",
+							org.apache.http.impl.cookie;version="[4.5,5)",
+							org.apache.http.message;version="[4.4,5)",
+							org.apache.http.protocol;version="[4.4,5)",
+							org.apache.http.util;version="[4.4,5)",
+							org.apache.http;version="[4.4,5)",
+
+							org.bouncycastle.asn1;version="[1.70,2)",
+							org.bouncycastle.asn1.x500;version="[1.70,2)",
+							org.bouncycastle.asn1.x500.style;version="[1.70,2)",
+							org.bouncycastle.asn1.x509;version="[1.70,2)",
+							org.bouncycastle.asn1.x9;version="[1.70,2)",
+							org.bouncycastle.cert;version="[1.70,2)",
+							org.bouncycastle.cert.jcajce;version="[1.70,2)",
+							org.bouncycastle.cert.ocsp;version="[1.70,2)",
+							org.bouncycastle.crypto;version="[1.70,2)",
+							org.bouncycastle.crypto.engines;version="[1.70,2)",
+							org.bouncycastle.crypto.params;version="[1.70,2)",
+							org.bouncycastle.jce;version="[1.70,2)",
+							org.bouncycastle.jce.provider;version="[1.70,2)",
+							org.bouncycastle.jce.spec;version="[1.70,2)",
+							org.bouncycastle.math.ec;version="[1.70,2)",
+							org.bouncycastle.openssl.jcajce;version="[1.70,2)",
+							org.bouncycastle.operator;version="[1.70,2)",
+							org.bouncycastle.operator.jcajce;version="[1.70,2)",
+
+							org.ietf.jgss;resolution:=optional,
+							org.jboss.logging;version="[3.4,4)"
+						</Import-Package>
+						<Embed-Dependency>
+							artifactId=keycloak-common;inline=keycloak-version.properties
+						</Embed-Dependency>
+						<_nouses>true</_nouses>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+
+		<!-- OSGi -->
+
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Logging -->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Keycloak -->
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-authz-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<!--
+				org.keycloak.adapters.KeycloakDeploymentBuilder.build(java.io.InputStream) calls
+				org.keycloak.common.crypto.CryptoIntegration.init(), which loads
+				/META-INF/services/org.keycloak.common.crypto.CryptoProvider service which is provided by several libs:
+				 - org.keycloak.crypto.def.DefaultCryptoProvider from org.keycloak/keycloak-crypto-default
+				 - org.keycloak.crypto.elytron.WildFlyElytronProvider from org.keycloak/keycloak-crypto-elytron
+				 - org.keycloak.crypto.fips.FIPS1402Provider from org.keycloak/keycloak-crypto-fips1402
+				SPI-Fly would be required, but only if keycloak-adapter-core had proper Require-Capability/Requirement
+				header.
+				It has (https://github.com/keycloak/keycloak/issues/9287) cap/req for
+				org.keycloak.adapters.authorization.ClaimInformationPointProviderFactory but misses few others, including
+				org.keycloak.common.crypto.CryptoProvider which is loaded through keycloak-common, which also misses
+				spi-fly req/cap.
+			-->
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-crypto-default</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/pax-web-keycloak21/keycloak21-common/src/main/java/org/keycloak/crypto/def/BCOCSPProvider.java
+++ b/pax-web-keycloak21/keycloak21-common/src/main/java/org/keycloak/crypto/def/BCOCSPProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.crypto.def;
+
+/**
+ * Special replacement of original {@code org.keycloak.crypto.def.BCOCSPProvider} to get rid of package dependencies
+ * on keycloak-server-spi[-private] libraries.
+ */
+public class BCOCSPProvider {
+}

--- a/pax-web-keycloak21/keycloak21-common/src/main/resources/META-INF/services/org.keycloak.adapters.authentication.ClientCredentialsProvider
+++ b/pax-web-keycloak21/keycloak21-common/src/main/resources/META-INF/services/org.keycloak.adapters.authentication.ClientCredentialsProvider
@@ -1,0 +1,19 @@
+#
+# Copyright 2023 OPS4J.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.adapters.authentication.ClientIdAndSecretCredentialsProvider
+org.keycloak.adapters.authentication.JWTClientCredentialsProvider
+org.keycloak.adapters.authentication.JWTClientSecretCredentialsProvider

--- a/pax-web-keycloak21/keycloak21-common/src/main/resources/META-INF/services/org.keycloak.adapters.authorization.ClaimInformationPointProviderFactory
+++ b/pax-web-keycloak21/keycloak21-common/src/main/resources/META-INF/services/org.keycloak.adapters.authorization.ClaimInformationPointProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2023 OPS4J.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.adapters.authorization.cip.ClaimsInformationPointProviderFactory
+org.keycloak.adapters.authorization.cip.HttpClaimInformationPointProviderFactory

--- a/pax-web-keycloak21/keycloak21-common/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProvider
+++ b/pax-web-keycloak21/keycloak21-common/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProvider
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 OPS4J.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.crypto.def.DefaultCryptoProvider

--- a/pax-web-keycloak21/keycloak21-osgi-adapter/pom.xml
+++ b/pax-web-keycloak21/keycloak21-osgi-adapter/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2023 OPS4J.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>pax-web-keycloak21</artifactId>
+		<version>9.0.6-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.ops4j.pax.web</groupId>
+	<artifactId>keycloak21-osgi-adapter</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>OPS4J Pax Web - Keycloak 21.x+ support - OSGi</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Export-Package>
+							org.keycloak.adapters.osgi;version="${dependency.org.keycloak21}"
+						</Export-Package>
+						<Import-Package>
+							org.keycloak.adapters;version="${dependency.org.keycloak21}",
+							org.keycloak.adapters.spi;version="${dependency.org.keycloak21}",
+							org.osgi.framework;version="[1.8,2)",
+							org.slf4j;version="[1.7,2)"
+						</Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+
+		<!-- OSGi -->
+
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>osgi.core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Logging -->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Keycloak -->
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-core</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/pax-web-keycloak21/keycloak21-osgi-adapter/src/main/java/org/keycloak/adapters/osgi/BundleBasedKeycloakConfigResolver.java
+++ b/pax-web-keycloak21/keycloak21-osgi-adapter/src/main/java/org/keycloak/adapters/osgi/BundleBasedKeycloakConfigResolver.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters.osgi;
+
+import org.keycloak.adapters.KeycloakConfigResolver;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.KeycloakDeploymentBuilder;
+import org.keycloak.adapters.spi.HttpFacade;
+import org.osgi.framework.BundleContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class BundleBasedKeycloakConfigResolver implements KeycloakConfigResolver {
+
+
+	private volatile KeycloakDeployment cachedDeployment;
+
+	private BundleContext bundleContext;
+	private String configLocation = "WEB-INF/keycloak.json";
+
+	public BundleContext getBundleContext() {
+		return bundleContext;
+	}
+
+	public void setBundleContext(BundleContext bundleContext) {
+		this.bundleContext = bundleContext;
+	}
+
+	public String getConfigLocation() {
+		return configLocation;
+	}
+
+	public void setConfigLocation(String configLocation) {
+		this.configLocation = configLocation;
+	}
+
+	@Override
+	public KeycloakDeployment resolve(HttpFacade.Request request) {
+		if (cachedDeployment != null) {
+			return cachedDeployment;
+		} else {
+			cachedDeployment = findDeployment(request);
+			return cachedDeployment;
+		}
+	}
+
+	protected KeycloakDeployment findDeployment(HttpFacade.Request request) {
+		if (bundleContext == null) {
+			throw new IllegalStateException("bundleContext must be set for BundleBasedKeycloakConfigResolver!");
+		}
+
+		URL url = bundleContext.getBundle().getResource(configLocation);
+		if (url == null) {
+			throw new IllegalStateException("Failed to find the file " + configLocation + " on classpath.");
+		}
+
+		try {
+			InputStream is = url.openStream();
+			return KeycloakDeploymentBuilder.build(is);
+		} catch (IOException ioe) {
+			throw new IllegalStateException("Error reading file' " + configLocation + "' from bundle classpath.", ioe);
+		}
+	}
+
+}

--- a/pax-web-keycloak21/keycloak21-osgi-adapter/src/main/java/org/keycloak/adapters/osgi/HierarchicalPathBasedKeycloakConfigResolver.java
+++ b/pax-web-keycloak21/keycloak21-osgi-adapter/src/main/java/org/keycloak/adapters/osgi/HierarchicalPathBasedKeycloakConfigResolver.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters.osgi;
+
+import org.keycloak.adapters.KeycloakConfigResolver;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.OIDCHttpFacade;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This {@link KeycloakConfigResolver} tries to resolve most specific configuration for given URI path. If not found,
+ * <em>parent</em> path is checked up to top-level path.
+ */
+public class HierarchicalPathBasedKeycloakConfigResolver extends PathBasedKeycloakConfigResolver {
+
+	public HierarchicalPathBasedKeycloakConfigResolver() {
+		prepopulateCache();
+	}
+
+	@Override
+	public KeycloakDeployment resolve(OIDCHttpFacade.Request request) {
+		// we cached all available deployments initially and now we'll try to check them from
+		// most specific to most general
+		URI uri = URI.create(request.getURI());
+		String path = uri.getPath();
+		if (path != null) {
+			while (path.startsWith("/")) {
+				path = path.substring(1);
+			}
+			String[] segments = path.split("/");
+			List<String> paths = collectPaths(segments);
+			for (String pathFragment: paths) {
+				KeycloakDeployment cachedDeployment = super.getCachedDeployment(pathFragment);
+				if (cachedDeployment != null) {
+					return cachedDeployment;
+				}
+			}
+		}
+
+		throw new IllegalStateException("Can't find Keycloak configuration related to URI path " + uri);
+	}
+
+	/**
+	 * <p>For segments like "a, b, c, d", returns:<ul>
+	 *     <li>"a-b-c-d"</li>
+	 *     <li>"a-b-c"</li>
+	 *     <li>"a-b"</li>
+	 *     <li>"a"</li>
+	 *     <li>""</li>
+	 * </ul></p>
+	 * @param segments
+	 * @return
+	 */
+	private List<String> collectPaths(String[] segments) {
+		List<String> result = new ArrayList<>(segments.length + 1);
+		for (int idx = segments.length; idx >= 0; idx--) {
+			StringBuilder sb = null;
+			for (int i = 0; i < idx; i++) {
+				if (sb == null) {
+					sb = new StringBuilder();
+				}
+				sb.append("-").append(segments[i]);
+			}
+			result.add(sb == null ? "" : sb.substring(1));
+		}
+		return result;
+	}
+
+}

--- a/pax-web-keycloak21/keycloak21-osgi-adapter/src/main/java/org/keycloak/adapters/osgi/PathBasedKeycloakConfigResolver.java
+++ b/pax-web-keycloak21/keycloak21-osgi-adapter/src/main/java/org/keycloak/adapters/osgi/PathBasedKeycloakConfigResolver.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.adapters.osgi;
+
+import org.keycloak.adapters.KeycloakConfigResolver;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.adapters.KeycloakDeploymentBuilder;
+import org.keycloak.adapters.OIDCHttpFacade;
+import org.keycloak.adapters.spi.HttpFacade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PathBasedKeycloakConfigResolver implements KeycloakConfigResolver {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(PathBasedKeycloakConfigResolver.class);
+
+	private final Map<String, KeycloakDeployment> cache = new ConcurrentHashMap<>();
+
+	private File keycloakConfigLocation = null;
+
+	public PathBasedKeycloakConfigResolver() {
+		String location = null;
+		String keycloakConfig = (String) System.getProperties().get("keycloak.config");
+		if (keycloakConfig != null && !"".equals(keycloakConfig.trim())) {
+			location = keycloakConfig;
+		} else {
+			String karafEtc = (String) System.getProperties().get("karaf.etc");
+			if (karafEtc != null && !"".equals(karafEtc.trim())) {
+				location = karafEtc;
+			}
+		}
+		if (location != null) {
+			File loc = new File(location);
+			if (loc.isDirectory()) {
+				keycloakConfigLocation = loc;
+			}
+		}
+	}
+
+	@Override
+	public KeycloakDeployment resolve(OIDCHttpFacade.Request request) {
+		String webContext = getDeploymentKeyForURI(request);
+
+		return getOrCreateDeployment(webContext);
+	}
+
+	/**
+	 * {@code pathFragment} is a key for {@link KeycloakDeployment deployments}. The key is used to construct
+	 * a path relative to {@code keycloak.config} or {@code karaf.etc} system properties.
+	 * For given key, {@code <key>-keycloak.json} file is checked.
+	 * @param pathFragment
+	 * @return
+	 */
+	protected synchronized KeycloakDeployment getOrCreateDeployment(String pathFragment) {
+		KeycloakDeployment deployment = getCachedDeployment(pathFragment);
+		if (null == deployment) {
+			// not found on the simple cache, try to load it from the file system
+			if (keycloakConfigLocation == null) {
+				throw new IllegalStateException("Neither \"keycloak.config\" nor \"karaf.etc\" java properties are set." +
+						" Please set one of them.");
+			}
+
+			File configuration = new File(keycloakConfigLocation, pathFragment + ("".equals(pathFragment) ? "" : "-")
+					+ "keycloak.json");
+			if (!cacheConfiguration(pathFragment, configuration)) {
+				throw new IllegalStateException("Not able to read the file " + configuration);
+			}
+			deployment = getCachedDeployment(pathFragment);
+		}
+
+		return deployment;
+	}
+
+	protected synchronized KeycloakDeployment getCachedDeployment(String pathFragment) {
+		return cache.get(pathFragment);
+	}
+
+	/**
+	 * If there's a need, we can pre populate the cache of deployments.
+	 */
+	protected void prepopulateCache() {
+		if (keycloakConfigLocation == null || !keycloakConfigLocation.isDirectory()) {
+			LOG.warn("Can't cache Keycloak configurations. No configuration storage is accessible." +
+					" Please set either \"keycloak.config\" or \"karaf.etc\" system properties");
+			return;
+		}
+
+		File[] configs = keycloakConfigLocation.listFiles(new FileFilter() {
+			@Override
+			public boolean accept(File pathname) {
+				return pathname.isFile() && pathname.getName().endsWith("keycloak.json");
+			}
+		});
+		if (configs != null) {
+			for (File config: configs) {
+				String pathFragment = null;
+				if ("keycloak.json".equals(config.getName())) {
+					pathFragment = "";
+				} else if (config.getName().endsWith("-keycloak.json")) {
+					pathFragment = config.getName()
+							.substring(0, config.getName().length() - "-keycloak.json".length());
+				}
+				cacheConfiguration(pathFragment, config);
+			}
+		}
+	}
+
+	private boolean cacheConfiguration(String key, File config) {
+		try {
+			InputStream is = new FileInputStream(config);
+			KeycloakDeployment deployment = KeycloakDeploymentBuilder.build(is);
+			cache.put(key, deployment);
+			return true;
+		} catch (FileNotFoundException | RuntimeException e) {
+			LOG.warn("Can't cache " + config + ": " + e.getMessage(), e);
+			return false;
+		}
+	}
+
+	/**
+	 * Finds a context path from given {@link HttpFacade.Request}. For default context, first path segment
+	 * is returned.
+	 * @param request
+	 * @return
+	 */
+	private String getDeploymentKeyForURI(HttpFacade.Request request) {
+		String uri = request.getURI();
+		String relativePath = request.getRelativePath();
+		String webContext;
+		if (relativePath == null || !uri.contains(relativePath)) {
+			String[] urlTokens = uri.split("/");
+			if (urlTokens.length <  4) {
+				throw new IllegalStateException("Not able to determine the web-context to load the correspondent keycloak.json file");
+			}
+
+			webContext = urlTokens[3];
+		} else {
+			URI parsedURI = URI.create(uri);
+			String path = parsedURI.getPath();
+			if (path.contains(relativePath)) {
+				path = path.substring(0, path.indexOf(relativePath));
+			}
+			while (path.startsWith("/")) {
+				path = path.substring(1);
+			}
+			webContext = path;
+			if ("".equals(webContext)) {
+				path = relativePath;
+				while (path.startsWith("/")) {
+					path = path.substring(1);
+				}
+				if (path.contains("/")) {
+					path = path.substring(0, path.indexOf("/"));
+				}
+				webContext = path;
+			}
+		}
+
+		return webContext;
+	}
+
+}

--- a/pax-web-keycloak21/pax-web-jetty-keycloak21/pom.xml
+++ b/pax-web-keycloak21/pax-web-jetty-keycloak21/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2023 OPS4J.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>pax-web-keycloak21</artifactId>
+		<version>9.0.6-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.ops4j.pax.web</groupId>
+	<artifactId>pax-web-jetty-keycloak21</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>OPS4J Pax Web - Keycloak 21.x+ support - Jetty 9.4</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Fragment-Host>org.ops4j.pax.web.pax-web-jetty</Fragment-Host>
+						<Private-Package>
+							org.ops4j.pax.web.keycloak.jetty,
+							org.keycloak.adapters.jetty,
+							org.keycloak.adapters.jetty.core,
+							org.keycloak.adapters.jetty.spi
+						</Private-Package>
+						<Export-Package>
+							org.keycloak.adapters.jetty;version=${dependency.org.keycloak21},
+							org.keycloak.adapters.jetty.core;version=${dependency.org.keycloak21},
+							org.keycloak.adapters.jetty.spi;version=${dependency.org.keycloak21}
+						</Export-Package>
+						<Import-Package>
+							org.ops4j.pax.web.service,
+							!org.keycloak.adapters.jetty.*,
+							org.jboss.logging;version="[3.4,4)",
+							*
+						</Import-Package>
+						<_contract>!*</_contract>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+
+		<!-- pax-web own artifacts -->
+
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>pax-web-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>pax-web-jetty</artifactId>
+		</dependency>
+
+		<!-- Jetty -->
+
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-security</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Keycloak -->
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-authz-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>keycloak21-osgi-adapter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-jetty-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-jetty-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-jetty94-adapter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/pax-web-keycloak21/pax-web-jetty-keycloak21/src/main/java/org/ops4j/pax/web/keycloak/jetty/KeycloakAuthenticatorService.java
+++ b/pax-web-keycloak21/pax-web-jetty-keycloak21/src/main/java/org/ops4j/pax/web/keycloak/jetty/KeycloakAuthenticatorService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.keycloak.jetty;
+
+import org.ops4j.pax.web.service.AuthenticatorService;
+
+public class KeycloakAuthenticatorService implements AuthenticatorService {
+
+	@Override
+	public <T> T getAuthenticatorService(String method, Class<T> iface) {
+		if (method == null || iface != org.eclipse.jetty.security.Authenticator.class) {
+			return null;
+		}
+
+		if ("KEYCLOAK".equalsIgnoreCase(method)) {
+			return iface.cast(new org.keycloak.adapters.jetty.KeycloakJettyAuthenticator());
+		}
+
+		return null;
+	}
+
+}

--- a/pax-web-keycloak21/pax-web-jetty-keycloak21/src/main/resources/META-INF/services/org.ops4j.pax.web.service.AuthenticatorService
+++ b/pax-web-keycloak21/pax-web-jetty-keycloak21/src/main/resources/META-INF/services/org.ops4j.pax.web.service.AuthenticatorService
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 OPS4J.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.ops4j.pax.web.keycloak.jetty.KeycloakAuthenticatorService

--- a/pax-web-keycloak21/pax-web-tomcat-keycloak21/pom.xml
+++ b/pax-web-keycloak21/pax-web-tomcat-keycloak21/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2023 OPS4J.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>pax-web-keycloak21</artifactId>
+		<version>9.0.6-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.ops4j.pax.web</groupId>
+	<artifactId>pax-web-tomcat-keycloak21</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>OPS4J Pax Web - Keycloak 21.x+ support - Tomcat 9</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Fragment-Host>org.ops4j.pax.web.pax-web-tomcat</Fragment-Host>
+						<Private-Package>
+							org.ops4j.pax.web.keycloak.tomcat,
+							org.keycloak.adapters.tomcat;-split-package:=merge-first
+						</Private-Package>
+						<Export-Package>
+							org.keycloak.adapters.tomcat;version=${dependency.org.keycloak21};-split-package:=merge-first
+						</Export-Package>
+						<Import-Package>
+							org.ops4j.pax.web.service,
+							!org.keycloak.adapters.tomcat,
+							org.jboss.logging;version="[3.4,4)",
+							*
+						</Import-Package>
+						<_contract>!*</_contract>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>pax-web-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>pax-web-tomcat</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Keycloak -->
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-authz-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>keycloak21-osgi-adapter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-tomcat-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-tomcat-core-adapter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-tomcat-adapter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/pax-web-keycloak21/pax-web-tomcat-keycloak21/src/main/java/org/ops4j/pax/web/keycloak/tomcat/KeycloakAuthenticatorService.java
+++ b/pax-web-keycloak21/pax-web-tomcat-keycloak21/src/main/java/org/ops4j/pax/web/keycloak/tomcat/KeycloakAuthenticatorService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.keycloak.tomcat;
+
+import org.ops4j.pax.web.service.AuthenticatorService;
+
+public class KeycloakAuthenticatorService implements AuthenticatorService {
+
+	@Override
+	public <T> T getAuthenticatorService(String method, Class<T> iface) {
+		if (method == null || iface != org.apache.catalina.Valve.class) {
+			return null;
+		}
+
+		if ("KEYCLOAK".equalsIgnoreCase(method)) {
+			return iface.cast(new org.keycloak.adapters.tomcat.KeycloakAuthenticatorValve());
+		}
+
+		return null;
+	}
+
+}

--- a/pax-web-keycloak21/pax-web-tomcat-keycloak21/src/main/resources/META-INF/services/org.ops4j.pax.web.service.AuthenticatorService
+++ b/pax-web-keycloak21/pax-web-tomcat-keycloak21/src/main/resources/META-INF/services/org.ops4j.pax.web.service.AuthenticatorService
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 OPS4J.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.ops4j.pax.web.keycloak.tomcat.KeycloakAuthenticatorService

--- a/pax-web-keycloak21/pax-web-undertow-keycloak21/pom.xml
+++ b/pax-web-keycloak21/pax-web-undertow-keycloak21/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2023 OPS4J.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>pax-web-keycloak21</artifactId>
+		<version>9.0.6-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.ops4j.pax.web</groupId>
+	<artifactId>pax-web-undertow-keycloak21</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>OPS4J Pax Web - Keycloak 21.x+ support - Undertow 2</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Fragment-Host>org.ops4j.pax.web.pax-web-undertow</Fragment-Host>
+						<Private-Package>
+							org.ops4j.pax.web.keycloak.undertow,
+							org.keycloak.adapters.undertow;-split-package:=merge-first
+						</Private-Package>
+						<Export-Package>
+							org.keycloak.adapters.undertow;version=${dependency.org.keycloak21};-split-package:=merge-first
+						</Export-Package>
+						<Import-Package>
+							org.ops4j.pax.web.service,
+							!org.keycloak.adapters.undertow,
+							org.jboss.logging;version="[3.4,4)",
+							*
+						</Import-Package>
+						<_contract>!*</_contract>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>pax-web-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>pax-web-undertow</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.undertow</groupId>
+			<artifactId>undertow-core</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Keycloak -->
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-authz-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.web</groupId>
+			<artifactId>keycloak21-osgi-adapter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-undertow-adapter-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-undertow-adapter</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/pax-web-keycloak21/pax-web-undertow-keycloak21/src/main/java/org/ops4j/pax/web/keycloak/undertow/KeycloakAuthenticatorService.java
+++ b/pax-web-keycloak21/pax-web-undertow-keycloak21/src/main/java/org/ops4j/pax/web/keycloak/undertow/KeycloakAuthenticatorService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 OPS4J.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.web.keycloak.undertow;
+
+import org.ops4j.pax.web.service.AuthenticatorService;
+
+public class KeycloakAuthenticatorService implements AuthenticatorService {
+
+	@Override
+	public <T> T getAuthenticatorService(String method, Class<T> iface) {
+		if (method == null || iface != io.undertow.servlet.ServletExtension.class) {
+			return null;
+		}
+
+		if ("KEYCLOAK".equalsIgnoreCase(method)) {
+			return iface.cast(new org.keycloak.adapters.undertow.KeycloakServletExtension());
+		}
+
+		return null;
+	}
+
+}

--- a/pax-web-keycloak21/pax-web-undertow-keycloak21/src/main/resources/META-INF/services/org.ops4j.pax.web.service.AuthenticatorService
+++ b/pax-web-keycloak21/pax-web-undertow-keycloak21/src/main/resources/META-INF/services/org.ops4j.pax.web.service.AuthenticatorService
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 OPS4J.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.ops4j.pax.web.keycloak.undertow.KeycloakAuthenticatorService

--- a/pax-web-keycloak21/pom.xml
+++ b/pax-web-keycloak21/pom.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.ops4j.pax</groupId>
+        <artifactId>web</artifactId>
+        <version>9.0.6-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.ops4j.pax.web</groupId>
+    <artifactId>pax-web-keycloak21</artifactId>
+    <packaging>pom</packaging>
+
+    <name>OPS4J Pax Web - Keycloak 21.x+ support</name>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <!--
+                Keycloak bundles once declared in keycloak-adapter-core (18.x) feature
+            -->
+
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-common</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-core</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-authz-client</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-spi</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-adapter-core</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+
+            <!-- New library in Keycloak 20 -->
+
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-crypto-default</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.keycloak</groupId>
+                        <artifactId>keycloak-server-spi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.keycloak</groupId>
+                        <artifactId>keycloak-server-spi-private</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- bundles from keycloak-pax-http-jetty feature (18.x) -->
+
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-jetty-adapter-spi</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-jetty-core</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-jetty94-adapter</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- org.keycloak/keycloak-pax-web-jetty94 is no longer available in Keycloak 20+ -->
+            <!--			<dependency>-->
+            <!--				<groupId>org.keycloak</groupId>-->
+            <!--				<artifactId>keycloak-pax-web-jetty94</artifactId>-->
+            <!--				<version>${dependency.org.keycloak21}</version>-->
+            <!--			</dependency>-->
+
+            <!-- bundles from keycloak-pax-http-tomcat feature (18.x) -->
+
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-tomcat-adapter-spi</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>tomcat-catalina</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-tomcat-core-adapter</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>tomcat-catalina</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-tomcat-adapter</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- org.keycloak/keycloak-pax-web-tomcat8 is no longer available in Keycloak 20+ -->
+            <!--			<dependency>-->
+            <!--				<groupId>org.keycloak</groupId>-->
+            <!--				<artifactId>keycloak-pax-web-tomcat8</artifactId>-->
+            <!--				<version>${dependency.org.keycloak21}</version>-->
+            <!--			</dependency>-->
+
+            <!-- bundles from keycloak-pax-http-undertow feature (18.x) -->
+            <!--			<bundle>mvn:org.keycloak/keycloak-camel-undertow/${project.version}</bundle>-->
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-undertow-adapter-spi</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-undertow-adapter</artifactId>
+                <version>${dependency.org.keycloak21}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- org.keycloak/keycloak-pax-web-undertow is no longer available in Keycloak 20+ -->
+            <!--			<dependency>-->
+            <!--				<groupId>org.keycloak</groupId>-->
+            <!--				<artifactId>keycloak-pax-web-undertow</artifactId>-->
+            <!--				<version>${dependency.org.keycloak21}</version>-->
+            <!--			</dependency>-->
+
+            <!-- bundles from keycloak-jaas feature (18.x) -->
+            <!--			<bundle>mvn:org.keycloak/keycloak-osgi-jaas/${project.version}</bundle>-->
+
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>keycloak21-common</module>
+        <module>keycloak21-osgi-adapter</module>
+        <module>pax-web-jetty-keycloak21</module>
+        <module>pax-web-tomcat-keycloak21</module>
+        <module>pax-web-undertow-keycloak21</module>
+    </modules>
+
+</project>

--- a/pax-web-keycloak21/readme.adoc
+++ b/pax-web-keycloak21/readme.adoc
@@ -1,0 +1,116 @@
+= Integration with Keycloak 19+
+
+More information is available in readme file for pax-web-keycloak18.
+
+For Keycloak 19+, where the OSGi/Karaf/Pax Web bits are removed, we have to repackage more. For Keycloak 18 we had to repackage Tomcat Keycloak libraries, for Keycloak 19+ we'll additionally repackage Jetty and Undertow ones.
+
+The Keycloak libraries that were providing `org.ops4j.pax.web.service.AuthenticatorService` services in Keycloak 18 were:
+
+* org.keycloak/keycloak-pax-web-jetty94
+* org.keycloak/keycloak-pax-web-tomcat8
+* org.keycloak/keycloak-pax-web-undertow
+
+While the Undertow related library provided only `org.keycloak.adapters.osgi.tomcat.KeycloakAuthenticatorService`, Jetty and Tomcat related libraries were providing additionally:
+
+* `org.keycloak.adapters.osgi.jetty94.PaxWebIntegrationService` - this was used to call Pax Web API methods:
+** `org.ops4j.pax.web.service.WebContainer.registerJettyWebXml()`
+** `org.ops4j.pax.web.service.WebContainer.registerConstraintMapping()`
+** `org.ops4j.pax.web.service.WebContainer.registerLoginConfig()`
+* `org.keycloak.adapters.osgi.undertow.PaxWebIntegrationService` - as above, but for Undertow
+* `org.keycloak.adapters.osgi.undertow.CxfKeycloakAuthHandler` - implementation of `org.apache.cxf.transport.http_undertow.CXFUndertowHttpHandler` for `org.apache.cxf/cxf-rt-transports-http-undertow`
+
+We don't backport the above to Pax Web for Keycloak 20+ support.
+
+== Installation
+
+The Keycloak integration tests can be performed using Apache Karaf 4.4.3.
+
+Before starting Karaf:
+----
+$ cat <<EOF >>etc/config.properties
+paxweb.authMethod = KEYCLOAK
+paxweb.keycloak.resolver = org.keycloak.adapters.osgi.PathBasedKeycloakConfigResolver
+EOF
+----
+
+In Karaf for Jetty:
+----
+karaf@root()> feature:install pax-web-http-jetty
+karaf@root()> feature:install pax-web-jsp
+karaf@root()> feature:install pax-web-whiteboard
+karaf@root()> feature:install pax-web-karaf
+karaf@root()> feature:install pax-web-jetty-keycloak21
+karaf@root()> install -s mvn:org.ops4j.pax.web.samples/whiteboard-security/8.0.15
+----
+
+In Karaf for Tomcat:
+----
+karaf@root()> feature:install pax-web-http-tomcat
+karaf@root()> feature:install pax-web-jsp
+karaf@root()> feature:install pax-web-whiteboard
+karaf@root()> feature:install pax-web-karaf
+karaf@root()> feature:install pax-web-tomcat-keycloak21
+karaf@root()> install -s mvn:org.ops4j.pax.web.samples/whiteboard-security/8.0.15
+----
+
+In Karaf for Undertow:
+----
+karaf@root()> feature:install pax-web-http-undertow
+karaf@root()> feature:install pax-web-jsp
+karaf@root()> feature:install pax-web-whiteboard
+karaf@root()> feature:install pax-web-karaf
+karaf@root()> feature:install pax-web-undertow-keycloak21
+karaf@root()> install -s mvn:org.ops4j.pax.web.samples/whiteboard-security/8.0.15
+----
+
+Before trying to run the example, we need running Keycloak 20 server:
+----
+$ pwd
+/data/servers/keycloak-20.0.3
+
+$ bin/kc.sh start-dev --http-port 8180
+2023-02-23 14:17:58,426 INFO  [org.keycloak.quarkus.runtime.hostname.DefaultHostnameProvider] (main) Hostname settings: Base URL: <unset>, Hostname: <request>, Strict HTTPS: false, Path: <request>, Strict BackChannel: false, Admin URL: <unset>, Admin: <request>, Port: -1, Proxied: false
+...
+2023-02-23 14:18:02,388 INFO  [io.quarkus] (main) Keycloak 20.0.3 on JVM (powered by Quarkus 2.13.6.Final) started in 5.805s. Listening on: http://0.0.0.0:8180
+...
+----
+
+Now, the Keycloak console is available at http://127.0.0.1:8180/admin/master/console/#/.
+
+We need to prepare some configuration:
+
+* separate realm called `paxweb`
+* `paxweb-admin` and `paxweb-viewer` roles
+* `admin` and `viewer` users (users' passwords must be set)
+* `whiteboard-customcontext` _client_ with `http://localhost:8181/pax-web-security/*` _Valid Redirect URIs_
+* `whiteboard-rootcontext` _client_ with `http://localhost:8181/*` _Valid Redirect URIs_
+
+Make sure that _Standard Flow Enabled_ is selected for the clients.
+
+After configuring the realm, roles, users and the clients, we can get the configurations and write them to Karaf's:
+
+`etc/whiteboard-customcontext-keycloak.json`:
+----
+{
+  "realm": "paxweb",
+  "auth-server-url": "http://127.0.0.1:8180/auth/",
+  "ssl-required": "external",
+  "resource": "whiteboard-customcontext",
+  "public-client": true,
+  "confidential-port": 0
+}
+----
+
+`etc/whiteboard-rootcontext-keycloak.json`:
+----
+{
+  "realm": "paxweb",
+  "auth-server-url": "http://127.0.0.1:8180/auth/",
+  "ssl-required": "external",
+  "resource": "whiteboard-rootcontext",
+  "public-client": true,
+  "confidential-port": 0
+}
+----
+
+If the resolver used is `org.keycloak.adapters.osgi.PathBasedKeycloakConfigResolver`, the configuration file for `/pax-web-security` context should be `etc/pax-web-security-keycloak.json`. This option is used to check different types of `org.keycloak.adapters.KeycloakConfigResolver` implementations.

--- a/pom.xml
+++ b/pom.xml
@@ -276,8 +276,9 @@
 
 		<dependency.org.jline>3.21.0</dependency.org.jline>
 		<dependency.org.jsoup>1.15.3</dependency.org.jsoup>
-		<dependency.org.keycloak18>18.0.3</dependency.org.keycloak18>
-		<dependency.org.keycloak20>20.0.3</dependency.org.keycloak20>
+		<dependency.org.keycloak18>18.0.2</dependency.org.keycloak18>
+		<dependency.org.keycloak20>20.0.5</dependency.org.keycloak20>
+		<dependency.org.keycloak21>21.0.0</dependency.org.keycloak21>
 		<dependency.org.mockito>4.11.0</dependency.org.mockito>
 		<dependency.org.mortbay.jetty.alpn>8.1.13.v20181017</dependency.org.mortbay.jetty.alpn>
 
@@ -1387,12 +1388,17 @@
 
 			<dependency>
 				<groupId>org.ops4j.pax.web</groupId>
+				<artifactId>pax-web-tomcat-keycloak18</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.ops4j.pax.web</groupId>
 				<artifactId>pax-web-jetty-keycloak20</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.ops4j.pax.web</groupId>
-				<artifactId>pax-web-tomcat-keycloak18</artifactId>
+				<artifactId>pax-web-jetty-keycloak21</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -1402,7 +1408,17 @@
 			</dependency>
 			<dependency>
 				<groupId>org.ops4j.pax.web</groupId>
+				<artifactId>pax-web-tomcat-keycloak21</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.ops4j.pax.web</groupId>
 				<artifactId>pax-web-undertow-keycloak20</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.ops4j.pax.web</groupId>
+				<artifactId>pax-web-undertow-keycloak21</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
@@ -1411,10 +1427,20 @@
 				<artifactId>keycloak20-common</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.ops4j.pax.web</groupId>
+				<artifactId>keycloak21-common</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
 			<dependency>
 				<groupId>org.ops4j.pax.web</groupId>
 				<artifactId>keycloak20-osgi-adapter</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.ops4j.pax.web</groupId>
+				<artifactId>keycloak21-osgi-adapter</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
@@ -3397,8 +3423,9 @@
 		<!-- Keycloak support -->
 		<module>pax-web-keycloak18</module>
 		<module>pax-web-keycloak20</module>
+        <module>pax-web-keycloak21</module>
 
-	</modules>
+    </modules>
 
 	<profiles>
 


### PR DESCRIPTION
Upgraded repackaged Keycloak 20 libraries to 20.0.5. 
Unable to source Keycloak 18.0.3 releases falling back to the 18.0.2 version.
Added repackaged Keycloak 21 libraries, addresses Pax-Web GitHub issue #1834