### PR TITLE
Fix welcome file model change in jetty wrapper

### DIFF
--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -1776,6 +1776,9 @@ class JettyServerWrapper implements BatchVisitor {
 								&& context == pwsh.getOsgiContextModel()) {
 							try {
 								Servlet servlet = sh.getServlet();
+								if (servlet instanceof ServletHolder.Wrapper) {
+									servlet = ((ServletHolder.Wrapper) servlet).getWrapped();
+								}
 								if (servlet instanceof JettyResourceServlet) {
 									((JettyResourceServlet) servlet).setWelcomeFiles(newWelcomeFiles);
 									((JettyResourceServlet) servlet).setWelcomeFilesRedirect(model.isRedirect());


### PR DESCRIPTION
Welcome files are not updated if a Servlet is wrapped into a `org.eclipse.jetty.servlet.ServletHolder.Wrapper` which is the default behaviour for not async servlet `org.eclipse.jetty.servlet.ServletHolder.NotAsync`.