### PR TITLE
[#2005] Adds missing bundle-version to Fragment-Host of pax-web-compatibility-servlet31

### DIFF
--- a/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
@@ -41,7 +41,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Fragment-Host>jakarta.servlet-api</Fragment-Host>
+						<Fragment-Host>jakarta.servlet-api;bundle-version="[4,5)"</Fragment-Host>
 						<Export-Package>
 							javax.servlet;version="3.1.0";uses:="javax.servlet.annotation,javax.servlet.descriptor",
 							javax.servlet;version="2.6";uses:="javax.servlet.annotation,javax.servlet.descriptor",


### PR DESCRIPTION
Adds missing bundle-version to Fragment-Host of pax-web-compatibility-servlet31 to solve #2005 