### PR TITLE
Pax-web-11.0.x

### DIFF
--- a/pax-web-api/src/main/java/org/ops4j/pax/web/utils/ClassPathUtil.java
+++ b/pax-web-api/src/main/java/org/ops4j/pax/web/utils/ClassPathUtil.java
@@ -162,7 +162,12 @@ public class ClassPathUtil {
 		} else {
 			String[] segments = bundleClasspath.split("\\s*,\\s*");
 			for (String segment : segments) {
-				final URL url = bundle.getEntry(segment);
+				final URL url;
+				if (".".equals(segment)) {
+					url = bundle.getEntry("/");
+				} else {
+					url = bundle.getEntry(segment);
+				}
 				if (url == null) {
 					continue;
 				}


### PR DESCRIPTION
Fixing problem with ClassPathUtil not scanning correctly classes for web annotations when Bundle-ClassPath is equal to ".".

https://github.com/ops4j/org.ops4j.pax.web/issues/2106