### PR TITLE
WebSocket deployment for servlets

### DIFF
--- a/pax-web-api/pom.xml
+++ b/pax-web-api/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-api/pom.xml
+++ b/pax-web-api/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-api/pom.xml
+++ b/pax-web-api/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-deployer/pom.xml
+++ b/pax-web-deployer/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-deployer/pom.xml
+++ b/pax-web-deployer/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-deployer/pom.xml
+++ b/pax-web-deployer/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-extender-war/pom.xml
+++ b/pax-web-extender-war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-extender-war/pom.xml
+++ b/pax-web-extender-war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-extender-war/pom.xml
+++ b/pax-web-extender-war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-extender-whiteboard/pom.xml
+++ b/pax-web-extender-whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-extender-whiteboard/pom.xml
+++ b/pax-web-extender-whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-extender-whiteboard/pom.xml
+++ b/pax-web-extender-whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-features/pom.xml
+++ b/pax-web-features/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-features/pom.xml
+++ b/pax-web-features/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-features/pom.xml
+++ b/pax-web-features/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-features/src/main/resources/features.xml
+++ b/pax-web-features/src/main/resources/features.xml
@@ -516,7 +516,7 @@ javax.servlet.context.tempdir = ${karaf.data}/pax-web/tmp
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${dependency.org.apache.httpcomponents.core4}</bundle>
 		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${dependency.org.apache.httpcomponents.client4}</bundle>
 
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${dependency.com.fasterxml.jackson.core}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${dependency.com.fasterxml.jackson.core.annotations}</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${dependency.com.fasterxml.jackson.core}</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${dependency.com.fasterxml.jackson.core.databind}</bundle>
 

--- a/pax-web-fragments/pax-web-compatibility-annotation13/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-annotation13/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-annotation13/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-annotation13/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-annotation13/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-annotation13/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-cdi12/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-cdi12/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-cdi12/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-cdi12/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-cdi12/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-cdi12/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-el2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-el2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-el2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-el2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-el2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-el2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-interceptor12/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-interceptor12/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-interceptor12/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-interceptor12/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-interceptor12/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-interceptor12/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-jaxrs2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-jaxrs2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-jaxrs2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-jaxrs2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-jaxrs2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-jaxrs2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-jpa2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-jpa2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-jpa2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-jpa2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-jpa2/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-jpa2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
+++ b/pax-web-fragments/pax-web-compatibility-servlet31/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-fragment-myfaces-inject/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-myfaces-inject/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-fragment-myfaces-inject/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-myfaces-inject/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-fragment-myfaces-inject/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-myfaces-inject/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-fragment-myfaces-spifly/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-myfaces-spifly/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-fragment-myfaces-spifly/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-myfaces-spifly/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pax-web-fragment-myfaces-spifly/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-myfaces-spifly/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-fragments</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pom.xml
+++ b/pax-web-fragments/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pom.xml
+++ b/pax-web-fragments/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-fragments/pom.xml
+++ b/pax-web-fragments/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-common/pom.xml
+++ b/pax-web-itest/pax-web-itest-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-common/pom.xml
+++ b/pax-web-itest/pax-web-itest-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-common/pom.xml
+++ b/pax-web-itest/pax-web-itest-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-common/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-common/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-container-common/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-container-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-jetty/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-jetty/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-jetty/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-tomcat/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-tomcat/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-tomcat/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-undertow/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-undertow/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pax-web-itest-undertow/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pax-web-itest-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.itest</groupId>
 		<artifactId>pax-web-itest-container</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-container/pom.xml
+++ b/pax-web-itest/pax-web-itest-container/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-jsp/pom.xml
+++ b/pax-web-itest/pax-web-itest-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-jsp/pom.xml
+++ b/pax-web-itest/pax-web-itest-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-jsp/pom.xml
+++ b/pax-web-itest/pax-web-itest-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-karaf/pom.xml
+++ b/pax-web-itest/pax-web-itest-karaf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-karaf/pom.xml
+++ b/pax-web-itest/pax-web-itest-karaf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-karaf/pom.xml
+++ b/pax-web-itest/pax-web-itest-karaf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-keycloak/pom.xml
+++ b/pax-web-itest/pax-web-itest-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-keycloak/pom.xml
+++ b/pax-web-itest/pax-web-itest-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-keycloak/pom.xml
+++ b/pax-web-itest/pax-web-itest-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-osgi/pom.xml
+++ b/pax-web-itest/pax-web-itest-osgi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-osgi/pom.xml
+++ b/pax-web-itest/pax-web-itest-osgi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-osgi/pom.xml
+++ b/pax-web-itest/pax-web-itest-osgi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-server/pom.xml
+++ b/pax-web-itest/pax-web-itest-server/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-server/pom.xml
+++ b/pax-web-itest/pax-web-itest-server/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-server/pom.xml
+++ b/pax-web-itest/pax-web-itest-server/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-utils/pom.xml
+++ b/pax-web-itest/pax-web-itest-utils/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-utils/pom.xml
+++ b/pax-web-itest/pax-web-itest-utils/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-itest-utils/pom.xml
+++ b/pax-web-itest/pax-web-itest-utils/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-tck/pom.xml
+++ b/pax-web-itest/pax-web-tck/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.33-SNAPSHOT</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pax-web-tck/pom.xml
+++ b/pax-web-itest/pax-web-tck/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-itest</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pom.xml
+++ b/pax-web-itest/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pom.xml
+++ b/pax-web-itest/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-itest/pom.xml
+++ b/pax-web-itest/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jetty-bundle/pom.xml
+++ b/pax-web-jetty-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jetty-bundle/pom.xml
+++ b/pax-web-jetty-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jetty-bundle/pom.xml
+++ b/pax-web-jetty-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jetty/pom.xml
+++ b/pax-web-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jetty/pom.xml
+++ b/pax-web-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jetty/pom.xml
+++ b/pax-web-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jsp/pom.xml
+++ b/pax-web-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jsp/pom.xml
+++ b/pax-web-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-jsp/pom.xml
+++ b/pax-web-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-karaf/pom.xml
+++ b/pax-web-karaf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-karaf/pom.xml
+++ b/pax-web-karaf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-karaf/pom.xml
+++ b/pax-web-karaf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/keycloak-common/pom.xml
+++ b/pax-web-keycloak/keycloak-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/keycloak-common/pom.xml
+++ b/pax-web-keycloak/keycloak-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/keycloak-common/pom.xml
+++ b/pax-web-keycloak/keycloak-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/keycloak-osgi-adapter/pom.xml
+++ b/pax-web-keycloak/keycloak-osgi-adapter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/keycloak-osgi-adapter/pom.xml
+++ b/pax-web-keycloak/keycloak-osgi-adapter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/keycloak-osgi-adapter/pom.xml
+++ b/pax-web-keycloak/keycloak-osgi-adapter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-jetty-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-jetty-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-jetty-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-jetty-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-jetty-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-jetty-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-tomcat-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-tomcat-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-tomcat-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-tomcat-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-tomcat-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-tomcat-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-undertow-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-undertow-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-undertow-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-undertow-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pax-web-undertow-keycloak/pom.xml
+++ b/pax-web-keycloak/pax-web-undertow-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pom.xml
+++ b/pax-web-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pom.xml
+++ b/pax-web-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak/pom.xml
+++ b/pax-web-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pax-web-jetty-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pax-web-jetty-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak18</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pax-web-jetty-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pax-web-jetty-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak18</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pax-web-jetty-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pax-web-jetty-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak18</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pax-web-tomcat-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pax-web-tomcat-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak18</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pax-web-tomcat-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pax-web-tomcat-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak18</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pax-web-tomcat-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pax-web-tomcat-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-keycloak18</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-keycloak18/pom.xml
+++ b/pax-web-keycloak18/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-manual/pom.xml
+++ b/pax-web-manual/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-manual/pom.xml
+++ b/pax-web-manual/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-manual/pom.xml
+++ b/pax-web-manual/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-report/pom.xml
+++ b/pax-web-report/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33-SNAPSHOT</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-report/pom.xml
+++ b/pax-web-report/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-api/pom.xml
+++ b/pax-web-resources/pax-web-resources-api/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-api/pom.xml
+++ b/pax-web-resources/pax-web-resources-api/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-api/pom.xml
+++ b/pax-web-resources/pax-web-resources-api/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-extender/pom.xml
+++ b/pax-web-resources/pax-web-resources-extender/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-extender/pom.xml
+++ b/pax-web-resources/pax-web-resources-extender/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-extender/pom.xml
+++ b/pax-web-resources/pax-web-resources-extender/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-jsf/pom.xml
+++ b/pax-web-resources/pax-web-resources-jsf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-jsf/pom.xml
+++ b/pax-web-resources/pax-web-resources-jsf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pax-web-resources-jsf/pom.xml
+++ b/pax-web-resources/pax-web-resources-jsf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>pax-web-resources</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pom.xml
+++ b/pax-web-resources/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pom.xml
+++ b/pax-web-resources/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-resources/pom.xml
+++ b/pax-web-resources/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-runtime/pom.xml
+++ b/pax-web-runtime/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-runtime/pom.xml
+++ b/pax-web-runtime/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-runtime/pom.xml
+++ b/pax-web-runtime/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-spi/pom.xml
+++ b/pax-web-spi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-spi/pom.xml
+++ b/pax-web-spi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-spi/pom.xml
+++ b/pax-web-spi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/elements/WebSocketModel.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/elements/WebSocketModel.java
@@ -147,7 +147,7 @@ public class WebSocketModel extends ElementModel<Object, WebSocketEventData> {
             }
         }
 
-        if (c.isAnnotationPresent(ServerEndpoint.class)) {
+        if (c != null && c.isAnnotationPresent(ServerEndpoint.class)) {
             ServerEndpoint endpoint = c.getAnnotation(ServerEndpoint.class);
             decoderClasses = endpoint.decoders();
             encoderClasses = endpoint.encoders();

--- a/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/elements/WebSocketModel.java
+++ b/pax-web-spi/src/main/java/org/ops4j/pax/web/service/spi/model/elements/WebSocketModel.java
@@ -114,7 +114,7 @@ public class WebSocketModel extends ElementModel<Object, WebSocketEventData> {
                     + " or service reference");
         }
         if (sources != 1) {
-            throw new IllegalArgumentException("WebSocket Model should specify a web socket uniquely as instance, class"
+            LOG.warn("WebSocket Model should specify a web socket uniquely as instance, class"
                     + " or service reference");
         }
 
@@ -147,10 +147,6 @@ public class WebSocketModel extends ElementModel<Object, WebSocketEventData> {
             }
         }
 
-        if (c == null) {
-            throw new IllegalArgumentException("Can't determine the Web Socket endpoint path.");
-        }
-
         if (c.isAnnotationPresent(ServerEndpoint.class)) {
             ServerEndpoint endpoint = c.getAnnotation(ServerEndpoint.class);
             decoderClasses = endpoint.decoders();
@@ -164,10 +160,13 @@ public class WebSocketModel extends ElementModel<Object, WebSocketEventData> {
                 return Boolean.TRUE;
             }
         }
-
         LOG.warn("Can't determine the Web Socket endpoint path - is @ServerEndpoint annotation present?");
 
-        return Boolean.FALSE;
+        return Boolean.TRUE;
+    }
+
+    public boolean hasEndpoint() {
+        return webSocketEndpointClassResolved != null && webSocketEndpointClassResolved.isAnnotationPresent(ServerEndpoint.class);
     }
 
     @Override

--- a/pax-web-tomcat-bundle/pom.xml
+++ b/pax-web-tomcat-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-bundle/pom.xml
+++ b/pax-web-tomcat-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-bundle/pom.xml
+++ b/pax-web-tomcat-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-common/pom.xml
+++ b/pax-web-tomcat-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-common/pom.xml
+++ b/pax-web-tomcat-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-common/pom.xml
+++ b/pax-web-tomcat-common/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-websocket/pom.xml
+++ b/pax-web-tomcat-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-websocket/pom.xml
+++ b/pax-web-tomcat-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat-websocket/pom.xml
+++ b/pax-web-tomcat-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-tomcat/pom.xml
+++ b/pax-web-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow-bundle/pom.xml
+++ b/pax-web-undertow-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow-bundle/pom.xml
+++ b/pax-web-undertow-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow-bundle/pom.xml
+++ b/pax-web-undertow-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow-websocket/pom.xml
+++ b/pax-web-undertow-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow-websocket/pom.xml
+++ b/pax-web-undertow-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow-websocket/pom.xml
+++ b/pax-web-undertow-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow/pom.xml
+++ b/pax-web-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow/pom.xml
+++ b/pax-web-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-undertow/pom.xml
+++ b/pax-web-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-websocket/pom.xml
+++ b/pax-web-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-websocket/pom.xml
+++ b/pax-web-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-websocket/pom.xml
+++ b/pax-web-websocket/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pax-web-websocket/src/main/java/org/ops4j/pax/web/websocket/internal/PaxWebWebSocketsServletContainerInitializer.java
+++ b/pax-web-websocket/src/main/java/org/ops4j/pax/web/websocket/internal/PaxWebWebSocketsServletContainerInitializer.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -53,7 +54,7 @@ public class PaxWebWebSocketsServletContainerInitializer implements ServletConta
 	private ContainerInitializerModel model;
 
 	@Override
-	public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException {
+	public void onStartup(final Set<Class<?>> c, final ServletContext ctx) throws ServletException {
 		ServerContainer wsContainer = (ServerContainer) ctx.getAttribute(ServerContainer.class.getName());
 
 		if (wsContainer == null) {
@@ -113,17 +114,21 @@ public class PaxWebWebSocketsServletContainerInitializer implements ServletConta
 
 				ServerEndpointConfig config = new DynamicEndpointConfig(wsm, instance);
 
-				try {
-					wsContainer.addEndpoint(config);
-				} catch (DeploymentException ex) {
-					LOG.error("Problem deploying Web Socket endpoint {}: {}", model, ex.getMessage(), ex);
+				if (wsm.hasEndpoint()) {
+					try {
+						wsContainer.addEndpoint(config);
+					} catch (DeploymentException ex) {
+						LOG.error("Problem deploying Web Socket endpoint {}: {}", model, ex.getMessage(), ex);
+					}
+				} else {
+					LOG.warn("WebSocket endpoint {} has no @ServerEndpoint annotation. It won't be registered.", model);
 				}
 			}
 		}
 	}
 
 	@Override
-	public void setContainerInitializerModel(ContainerInitializerModel model) {
+	public void setContainerInitializerModel(final ContainerInitializerModel model) {
 		this.model = model;
 	}
 
@@ -140,7 +145,7 @@ public class PaxWebWebSocketsServletContainerInitializer implements ServletConta
 		// org.apache.tomcat.websocket.pojo.Constants.POJO_METHOD_MAPPING_KEY mapping
 		private final Map<String, Object> userProperties = new HashMap<>();
 
-		DynamicEndpointConfig(WebSocketModel wsm, Object instance) {
+		DynamicEndpointConfig(final WebSocketModel wsm, final Object instance) {
 			this.wsm = wsm;
 			this.instance = instance;
 		}
@@ -171,7 +176,7 @@ public class PaxWebWebSocketsServletContainerInitializer implements ServletConta
 			// so we actually return proper instance
 			return new Configurator() {
 				@Override
-				public <T> T getEndpointInstance(Class<T> endpointClass) {
+				public <T> T getEndpointInstance(final Class<T> endpointClass) {
 					return endpointClass.cast(instance);
 				}
 			};

--- a/pom.xml
+++ b/pom.xml
@@ -732,6 +732,8 @@
 				<configuration>
 					<!-- you need <server> with such <id> in ~/.m2/repository -->
 					<publishingServerId>ossrh-central</publishingServerId>
+					<deploymentName>pax-web-${project.version}</deploymentName>
+					<waitUntil>uploaded</waitUntil>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>org.ops4j.pax</groupId>
 	<artifactId>web</artifactId>
-	<version>8.0.34-SNAPSHOT</version>
+	<version>8.0.34</version>
 	<packaging>pom</packaging>
 
 	<name>OPS4J Pax Web</name>
@@ -46,7 +46,7 @@
 		<connection>scm:git:git@github.com:ops4j/org.ops4j.pax.web.git</connection>
 		<developerConnection>scm:git:git@github.com:ops4j/org.ops4j.pax.web.git</developerConnection>
 		<url>https://github.com/ops4j/org.ops4j.pax.web/tree/pax-web-8.0.x</url>
-		<tag>HEAD</tag>
+		<tag>web-8.0.34</tag>
     </scm>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -263,8 +263,8 @@
 		<dependency.org.eclipse.jdt.ecj>3.26.0</dependency.org.eclipse.jdt.ecj>
 
 		<!-- Please keep Maven and OSGi version in sync -->
-		<dependency.org.eclipse.jetty>9.4.57.v20241219</dependency.org.eclipse.jetty>
-		<dependency.org.eclipse.jetty.osgi>9.4.57</dependency.org.eclipse.jetty.osgi>
+		<dependency.org.eclipse.jetty>9.4.58.v20250814</dependency.org.eclipse.jetty>
+		<dependency.org.eclipse.jetty.osgi>9.4.58</dependency.org.eclipse.jetty.osgi>
 		<dependency.org.eclipse.jetty.alpn>1.1.3.v20160715</dependency.org.eclipse.jetty.alpn>
 		<dependency.org.eclipse.jetty.alpn.osgi>1.1.3</dependency.org.eclipse.jetty.alpn.osgi>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>org.ops4j.pax</groupId>
 	<artifactId>web</artifactId>
-	<version>8.0.34</version>
+	<version>8.0.35-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>OPS4J Pax Web</name>
@@ -46,7 +46,7 @@
 		<connection>scm:git:git@github.com:ops4j/org.ops4j.pax.web.git</connection>
 		<developerConnection>scm:git:git@github.com:ops4j/org.ops4j.pax.web.git</developerConnection>
 		<url>https://github.com/ops4j/org.ops4j.pax.web/tree/pax-web-8.0.x</url>
-		<tag>web-8.0.34</tag>
+		<tag>HEAD</tag>
     </scm>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>org.ops4j.pax</groupId>
 	<artifactId>web</artifactId>
-	<version>8.0.33</version>
+	<version>8.0.34-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>OPS4J Pax Web</name>

--- a/pom.xml
+++ b/pom.xml
@@ -176,8 +176,9 @@
 		<!-- 2.20.0 requires java.nio.file.spi not exported by Karaf 4.3 -->
 		<dependency.commons-io>2.19.0</dependency.commons-io>
 		<dependency.com.fasterxml.classmate>1.7.0</dependency.com.fasterxml.classmate>
-		<dependency.com.fasterxml.jackson.core>2.19.2</dependency.com.fasterxml.jackson.core>
-		<dependency.com.fasterxml.jackson.core.databind>2.19.2</dependency.com.fasterxml.jackson.core.databind>
+		<dependency.com.fasterxml.jackson.core>2.20.0</dependency.com.fasterxml.jackson.core>
+		<dependency.com.fasterxml.jackson.core.annotations>2.20</dependency.com.fasterxml.jackson.core.annotations>
+		<dependency.com.fasterxml.jackson.core.databind>2.20.0</dependency.com.fasterxml.jackson.core.databind>
 		<dependency.com.fasterxml.woodstox>6.7.0</dependency.com.fasterxml.woodstox>
 		<dependency.com.sun.activation>1.2.0</dependency.com.sun.activation>
 		<dependency.com.sun.istack>3.0.12</dependency.com.sun.istack>
@@ -207,7 +208,7 @@
 
 		<dependency.junit>4.13.2</dependency.junit>
 
-		<dependency.net.bytebuddy>1.17.6</dependency.net.bytebuddy>
+		<dependency.net.bytebuddy>1.17.7</dependency.net.bytebuddy>
 
 		<dependency.org.apache.aries.cdi>1.1.5</dependency.org.apache.aries.cdi>
 		<dependency.org.apache.aries.component-dsl>1.2.2</dependency.org.apache.aries.component-dsl>
@@ -219,7 +220,7 @@
 		<dependency.org.apache.cxf>3.5.8</dependency.org.apache.cxf>
 
 		<dependency.org.apache.commons.collections4>4.5.0</dependency.org.apache.commons.collections4>
-		<dependency.org.apache.commons.compress>1.27.1</dependency.org.apache.commons.compress>
+		<dependency.org.apache.commons.compress>1.28.0</dependency.org.apache.commons.compress>
 		<dependency.org.apache.commons.lang3>3.18.0</dependency.org.apache.commons.lang3>
 
 		<dependency.org.apache.felix.configadmin>1.9.26</dependency.org.apache.felix.configadmin>
@@ -241,7 +242,7 @@
 		<dependency.org.apache.httpcomponents.client4>4.5.14</dependency.org.apache.httpcomponents.client4>
 		<dependency.org.apache.httpcomponents.client5>5.5</dependency.org.apache.httpcomponents.client5>
 		<dependency.org.apache.httpcomponents.core4>4.4.16</dependency.org.apache.httpcomponents.core4>
-		<dependency.org.apache.httpcomponents.core5>5.3.4</dependency.org.apache.httpcomponents.core5>
+		<dependency.org.apache.httpcomponents.core5>5.3.5</dependency.org.apache.httpcomponents.core5>
 		<dependency.org.apache.karaf>4.3.10</dependency.org.apache.karaf>
 		<dependency.org.apache.logging.log4j>2.25.1</dependency.org.apache.logging.log4j>
 		<dependency.org.apache.myfaces>2.3.11</dependency.org.apache.myfaces>
@@ -255,8 +256,8 @@
 		<dependency.org.apache.ws.xmlschema>2.3.1</dependency.org.apache.ws.xmlschema>
 		<dependency.org.apache.xbean>4.27</dependency.org.apache.xbean>
 
-		<dependency.org.assertj>3.27.3</dependency.org.assertj>
-		<dependency.org.bouncycastle>1.81</dependency.org.bouncycastle>
+		<dependency.org.assertj>3.27.4</dependency.org.assertj>
+		<dependency.org.bouncycastle>1.82</dependency.org.bouncycastle>
 		<dependency.org.codehaus.woodstox.stax2-api>4.2.2</dependency.org.codehaus.woodstox.stax2-api>
 
 		<!-- 3.26.0 is the last version supporting JDK 8 -->
@@ -289,7 +290,7 @@
 		<dependency.org.jboss.xnio>3.8.16.Final</dependency.org.jboss.xnio>
 
 		<dependency.org.jline>3.21.0</dependency.org.jline>
-		<dependency.org.jsoup>1.21.1</dependency.org.jsoup>
+		<dependency.org.jsoup>1.21.2</dependency.org.jsoup>
 		<!-- Special version of Keycloak that will never exceed 18.0.x - the last version with OSGi/Karaf/PaxWeb support -->
 		<dependency.org.keycloak18>18.0.2</dependency.org.keycloak18>
 		<!-- Keycloak version newer than 18 - just the latest available upstream version -->
@@ -321,7 +322,7 @@
 
 		<dependency.org.ow2.asm>9.8</dependency.org.ow2.asm>
 		<dependency.org.owasp.encoder>1.3.1</dependency.org.owasp.encoder>
-		<dependency.org.primefaces>13.0.17-LTS</dependency.org.primefaces>
+		<dependency.org.primefaces>13.0.19-LTS</dependency.org.primefaces>
 		<dependency.org.slf4j>2.0.17</dependency.org.slf4j>
 		<dependency.org.springframework>5.3.39</dependency.org.springframework>
 		<dependency.org.vaadin.artur>1.7.1</dependency.org.vaadin.artur>
@@ -330,7 +331,7 @@
 		<!-- 1.7.0.Final is JDK 11 -->
 		<dependency.org.wildfly.common>1.6.0.Final</dependency.org.wildfly.common>
 
-		<dependency.org.yaml.snakeyaml>2.4</dependency.org.yaml.snakeyaml>
+		<dependency.org.yaml.snakeyaml>2.5</dependency.org.yaml.snakeyaml>
 	</properties>
 
 	<build>
@@ -3289,7 +3290,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>${dependency.com.fasterxml.jackson.core}</version>
+				<version>${dependency.com.fasterxml.jackson.core.annotations}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<connection>scm:git:git@github.com:ops4j/org.ops4j.pax.web.git</connection>
 		<developerConnection>scm:git:git@github.com:ops4j/org.ops4j.pax.web.git</developerConnection>
 		<url>https://github.com/ops4j/org.ops4j.pax.web/tree/pax-web-8.0.x</url>
-		<tag>web-8.0.33</tag>
+		<tag>HEAD</tag>
     </scm>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -134,18 +134,18 @@
 		<plugin.maven-deploy-plugin>3.1.4</plugin.maven-deploy-plugin>
 		<plugin.maven-enforcer-plugin>3.6.1</plugin.maven-enforcer-plugin>
 		<plugin.dependency.org.commonjava.maven.enforcer>1.3</plugin.dependency.org.commonjava.maven.enforcer>
-		<plugin.maven-failsafe-plugin>3.5.3</plugin.maven-failsafe-plugin>
+		<plugin.maven-failsafe-plugin>3.5.4</plugin.maven-failsafe-plugin>
 		<plugin.maven-gpg-plugin>3.2.8</plugin.maven-gpg-plugin>
 		<plugin.maven-install-plugin>3.1.4</plugin.maven-install-plugin>
 		<plugin.maven-jar-plugin>3.4.2</plugin.maven-jar-plugin>
-		<plugin.maven-javadoc-plugin>3.11.2</plugin.maven-javadoc-plugin>
+		<plugin.maven-javadoc-plugin>3.11.3</plugin.maven-javadoc-plugin>
 		<plugin.maven-release-plugin>3.1.1</plugin.maven-release-plugin>
 		<plugin.maven-remote-resources-plugin>3.3.0</plugin.maven-remote-resources-plugin>
 		<plugin.maven-resources-plugin>3.3.1</plugin.maven-resources-plugin>
 		<plugin.dependency.maven-filtering>3.4.0</plugin.dependency.maven-filtering>
 		<plugin.maven-site-plugin>3.21.0</plugin.maven-site-plugin>
 		<plugin.maven-source-plugin>3.3.1</plugin.maven-source-plugin>
-		<plugin.maven-surefire-plugin>3.5.3</plugin.maven-surefire-plugin>
+		<plugin.maven-surefire-plugin>3.5.4</plugin.maven-surefire-plugin>
 		<plugin.maven-war-plugin>3.4.0</plugin.maven-war-plugin>
 
 		<!-- Other Maven plugins (and their dependencies) -->

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
 		<dependency.org.apache.servicemix.bundles.jasypt>1.9.3_1</dependency.org.apache.servicemix.bundles.jasypt>
 		<dependency.org.apache.servicemix.bundles.javax-inject>1_3</dependency.org.apache.servicemix.bundles.javax-inject>
 		<dependency.org.apache.taglibs>1.2.5</dependency.org.apache.taglibs>
-		<dependency.org.apache.tomcat>9.0.107</dependency.org.apache.tomcat>
+		<dependency.org.apache.tomcat>9.0.109</dependency.org.apache.tomcat>
 		<dependency.org.apache.ws.xmlschema>2.3.1</dependency.org.apache.ws.xmlschema>
 		<dependency.org.apache.xbean>4.27</dependency.org.apache.xbean>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax</groupId>
 		<artifactId>web</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-jetty/pom.xml
+++ b/samples/samples-config/auth-config-fragment-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-jetty/pom.xml
+++ b/samples/samples-config/auth-config-fragment-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-jetty/pom.xml
+++ b/samples/samples-config/auth-config-fragment-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/auth-config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/auth-config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/auth-config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-undertow/pom.xml
+++ b/samples/samples-config/auth-config-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-undertow/pom.xml
+++ b/samples/samples-config/auth-config-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/auth-config-fragment-undertow/pom.xml
+++ b/samples/samples-config/auth-config-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-jetty/pom.xml
+++ b/samples/samples-config/config-fragment-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-jetty/pom.xml
+++ b/samples/samples-config/config-fragment-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-jetty/pom.xml
+++ b/samples/samples-config/config-fragment-jetty/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-tomcat-vhosts/pom.xml
+++ b/samples/samples-config/config-fragment-tomcat-vhosts/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-tomcat-vhosts/pom.xml
+++ b/samples/samples-config/config-fragment-tomcat-vhosts/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-tomcat-vhosts/pom.xml
+++ b/samples/samples-config/config-fragment-tomcat-vhosts/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-undertow-vhosts/pom.xml
+++ b/samples/samples-config/config-fragment-undertow-vhosts/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-undertow-vhosts/pom.xml
+++ b/samples/samples-config/config-fragment-undertow-vhosts/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/config-fragment-undertow-vhosts/pom.xml
+++ b/samples/samples-config/config-fragment-undertow-vhosts/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/limit-post-config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/limit-post-config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/limit-post-config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/limit-post-config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/limit-post-config-fragment-tomcat/pom.xml
+++ b/samples/samples-config/limit-post-config-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/limit-post-config-fragment-undertow/pom.xml
+++ b/samples/samples-config/limit-post-config-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/limit-post-config-fragment-undertow/pom.xml
+++ b/samples/samples-config/limit-post-config-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/limit-post-config-fragment-undertow/pom.xml
+++ b/samples/samples-config/limit-post-config-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/pom.xml
+++ b/samples/samples-config/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/pom.xml
+++ b/samples/samples-config/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/pom.xml
+++ b/samples/samples-config/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/showcase/pom.xml
+++ b/samples/samples-config/showcase/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/showcase/pom.xml
+++ b/samples/samples-config/showcase/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-config/showcase/pom.xml
+++ b/samples/samples-config/showcase/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-config</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/authentication/pom.xml
+++ b/samples/samples-httpservice/authentication/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/authentication/pom.xml
+++ b/samples/samples-httpservice/authentication/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/authentication/pom.xml
+++ b/samples/samples-httpservice/authentication/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-1/pom.xml
+++ b/samples/samples-httpservice/hs-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-1/pom.xml
+++ b/samples/samples-httpservice/hs-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-1/pom.xml
+++ b/samples/samples-httpservice/hs-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-2/pom.xml
+++ b/samples/samples-httpservice/hs-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-2/pom.xml
+++ b/samples/samples-httpservice/hs-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-2/pom.xml
+++ b/samples/samples-httpservice/hs-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-for-war-default/pom.xml
+++ b/samples/samples-httpservice/hs-for-war-default/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-for-war-default/pom.xml
+++ b/samples/samples-httpservice/hs-for-war-default/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-for-war-default/pom.xml
+++ b/samples/samples-httpservice/hs-for-war-default/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-helloworld/pom.xml
+++ b/samples/samples-httpservice/hs-helloworld/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-helloworld/pom.xml
+++ b/samples/samples-httpservice/hs-helloworld/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-helloworld/pom.xml
+++ b/samples/samples-httpservice/hs-helloworld/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-jersey/pom.xml
+++ b/samples/samples-httpservice/hs-jersey/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-jersey/pom.xml
+++ b/samples/samples-httpservice/hs-jersey/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/hs-jersey/pom.xml
+++ b/samples/samples-httpservice/hs-jersey/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/http-custom-context/pom.xml
+++ b/samples/samples-httpservice/http-custom-context/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/http-custom-context/pom.xml
+++ b/samples/samples-httpservice/http-custom-context/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/http-custom-context/pom.xml
+++ b/samples/samples-httpservice/http-custom-context/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/pom.xml
+++ b/samples/samples-httpservice/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/pom.xml
+++ b/samples/samples-httpservice/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/pom.xml
+++ b/samples/samples-httpservice/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/wc-helloworld/pom.xml
+++ b/samples/samples-httpservice/wc-helloworld/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/wc-helloworld/pom.xml
+++ b/samples/samples-httpservice/wc-helloworld/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-httpservice/wc-helloworld/pom.xml
+++ b/samples/samples-httpservice/wc-helloworld/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-httpservice</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers-fragment1/pom.xml
+++ b/samples/samples-internal/initializers-fragment1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers-fragment1/pom.xml
+++ b/samples/samples-internal/initializers-fragment1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers-fragment1/pom.xml
+++ b/samples/samples-internal/initializers-fragment1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers-fragment2/pom.xml
+++ b/samples/samples-internal/initializers-fragment2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers-fragment2/pom.xml
+++ b/samples/samples-internal/initializers-fragment2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers-fragment2/pom.xml
+++ b/samples/samples-internal/initializers-fragment2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers/pom.xml
+++ b/samples/samples-internal/initializers/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers/pom.xml
+++ b/samples/samples-internal/initializers/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/initializers/pom.xml
+++ b/samples/samples-internal/initializers/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/pax-web-spi-fragment/pom.xml
+++ b/samples/samples-internal/pax-web-spi-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/pax-web-spi-fragment/pom.xml
+++ b/samples/samples-internal/pax-web-spi-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/pax-web-spi-fragment/pom.xml
+++ b/samples/samples-internal/pax-web-spi-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-internal</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/pom.xml
+++ b/samples/samples-internal/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/pom.xml
+++ b/samples/samples-internal/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-internal/pom.xml
+++ b/samples/samples-internal/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons1/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons1/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons1/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons2/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons2/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons2/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons3/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons3/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-commons3/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-commons3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-embedded-fragment/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-embedded-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-embedded-fragment/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-embedded-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-embedded-fragment/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-embedded-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-embedded/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-embedded/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-embedded/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-jar/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-jar/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-jar/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-jar/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-primefaces-jar/pom.xml
+++ b/samples/samples-jsf/jsf-primefaces-jar/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-myfaces/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-myfaces/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-myfaces/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-myfaces/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-myfaces/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-myfaces/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle-override/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle-override/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle-override/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle-override/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle-override/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle-override/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/jsf-resourcehandler-resourcebundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>jsf-resourcehandler</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/jsf-resourcehandler/pom.xml
+++ b/samples/samples-jsf/jsf-resourcehandler/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/pom.xml
+++ b/samples/samples-jsf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/pom.xml
+++ b/samples/samples-jsf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/pom.xml
+++ b/samples/samples-jsf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-cdi/pom.xml
+++ b/samples/samples-jsf/war-jsf23-cdi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-cdi/pom.xml
+++ b/samples/samples-jsf/war-jsf23-cdi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-cdi/pom.xml
+++ b/samples/samples-jsf/war-jsf23-cdi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-embedded/pom.xml
+++ b/samples/samples-jsf/war-jsf23-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-embedded/pom.xml
+++ b/samples/samples-jsf/war-jsf23-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-embedded/pom.xml
+++ b/samples/samples-jsf/war-jsf23-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-wired/pom.xml
+++ b/samples/samples-jsf/war-jsf23-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-wired/pom.xml
+++ b/samples/samples-jsf/war-jsf23-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-jsf23-wired/pom.xml
+++ b/samples/samples-jsf/war-jsf23-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-primefaces-embedded/pom.xml
+++ b/samples/samples-jsf/war-primefaces-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-primefaces-embedded/pom.xml
+++ b/samples/samples-jsf/war-primefaces-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-primefaces-embedded/pom.xml
+++ b/samples/samples-jsf/war-primefaces-embedded/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-primefaces-wired/pom.xml
+++ b/samples/samples-jsf/war-primefaces-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-primefaces-wired/pom.xml
+++ b/samples/samples-jsf/war-primefaces-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsf/war-primefaces-wired/pom.xml
+++ b/samples/samples-jsf/war-primefaces-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsf</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/helloworld-jsp-noclasses/pom.xml
+++ b/samples/samples-jsp/helloworld-jsp-noclasses/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsp</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/helloworld-jsp-noclasses/pom.xml
+++ b/samples/samples-jsp/helloworld-jsp-noclasses/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsp</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/helloworld-jsp-noclasses/pom.xml
+++ b/samples/samples-jsp/helloworld-jsp-noclasses/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsp</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/helloworld-jsp/pom.xml
+++ b/samples/samples-jsp/helloworld-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsp</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/helloworld-jsp/pom.xml
+++ b/samples/samples-jsp/helloworld-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsp</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/helloworld-jsp/pom.xml
+++ b/samples/samples-jsp/helloworld-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-jsp</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/pom.xml
+++ b/samples/samples-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/pom.xml
+++ b/samples/samples-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-jsp/pom.xml
+++ b/samples/samples-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/helloworld-servlet3/pom.xml
+++ b/samples/samples-war/helloworld-servlet3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/helloworld-servlet3/pom.xml
+++ b/samples/samples-war/helloworld-servlet3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/helloworld-servlet3/pom.xml
+++ b/samples/samples-war/helloworld-servlet3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/jsp-filter/pom.xml
+++ b/samples/samples-war/jsp-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/jsp-filter/pom.xml
+++ b/samples/samples-war/jsp-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/jsp-filter/pom.xml
+++ b/samples/samples-war/jsp-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/pom.xml
+++ b/samples/samples-war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/pom.xml
+++ b/samples/samples-war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/pom.xml
+++ b/samples/samples-war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/simple-filter/pom.xml
+++ b/samples/samples-war/simple-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/simple-filter/pom.xml
+++ b/samples/samples-war/simple-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/simple-filter/pom.xml
+++ b/samples/samples-war/simple-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/filter-bundle/pom.xml
+++ b/samples/samples-war/wab-and-filter/filter-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/filter-bundle/pom.xml
+++ b/samples/samples-war/wab-and-filter/filter-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/filter-bundle/pom.xml
+++ b/samples/samples-war/wab-and-filter/filter-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/pom.xml
+++ b/samples/samples-war/wab-and-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/pom.xml
+++ b/samples/samples-war/wab-and-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/pom.xml
+++ b/samples/samples-war/wab-and-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/wab-using-filter/pom.xml
+++ b/samples/samples-war/wab-and-filter/wab-using-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/wab-using-filter/pom.xml
+++ b/samples/samples-war/wab-and-filter/wab-using-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-and-filter/wab-using-filter/pom.xml
+++ b/samples/samples-war/wab-and-filter/wab-using-filter/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-container-context-config/pom.xml
+++ b/samples/samples-war/wab-container-context-config/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-container-context-config/pom.xml
+++ b/samples/samples-war/wab-container-context-config/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/wab-container-context-config/pom.xml
+++ b/samples/samples-war/wab-container-context-config/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-authentication/pom.xml
+++ b/samples/samples-war/war-authentication/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-authentication/pom.xml
+++ b/samples/samples-war/war-authentication/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-authentication/pom.xml
+++ b/samples/samples-war/war-authentication/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-default/pom.xml
+++ b/samples/samples-war/war-default/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-default/pom.xml
+++ b/samples/samples-war/war-default/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-default/pom.xml
+++ b/samples/samples-war/war-default/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-dispatch-jsp/pom.xml
+++ b/samples/samples-war/war-dispatch-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-dispatch-jsp/pom.xml
+++ b/samples/samples-war/war-dispatch-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-dispatch-jsp/pom.xml
+++ b/samples/samples-war/war-dispatch-jsp/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-dispatcher/pom.xml
+++ b/samples/samples-war/war-dispatcher/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-dispatcher/pom.xml
+++ b/samples/samples-war/war-dispatcher/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-dispatcher/pom.xml
+++ b/samples/samples-war/war-dispatcher/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-filters/pom.xml
+++ b/samples/samples-war/war-filters/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-filters/pom.xml
+++ b/samples/samples-war/war-filters/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-filters/pom.xml
+++ b/samples/samples-war/war-filters/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-formauth/pom.xml
+++ b/samples/samples-war/war-formauth/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-formauth/pom.xml
+++ b/samples/samples-war/war-formauth/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-formauth/pom.xml
+++ b/samples/samples-war/war-formauth/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-http-methods/pom.xml
+++ b/samples/samples-war/war-http-methods/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-http-methods/pom.xml
+++ b/samples/samples-war/war-http-methods/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-http-methods/pom.xml
+++ b/samples/samples-war/war-http-methods/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-http2/pom.xml
+++ b/samples/samples-war/war-http2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-http2/pom.xml
+++ b/samples/samples-war/war-http2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-http2/pom.xml
+++ b/samples/samples-war/war-http2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-introspection-bundle/pom.xml
+++ b/samples/samples-war/war-introspection-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-introspection-bundle/pom.xml
+++ b/samples/samples-war/war-introspection-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-introspection-bundle/pom.xml
+++ b/samples/samples-war/war-introspection-bundle/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-introspection/pom.xml
+++ b/samples/samples-war/war-introspection/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-introspection/pom.xml
+++ b/samples/samples-war/war-introspection/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-introspection/pom.xml
+++ b/samples/samples-war/war-introspection/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-jetty-web/pom.xml
+++ b/samples/samples-war/war-jetty-web/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-jetty-web/pom.xml
+++ b/samples/samples-war/war-jetty-web/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-jetty-web/pom.xml
+++ b/samples/samples-war/war-jetty-web/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-keycloak/pom.xml
+++ b/samples/samples-war/war-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-keycloak/pom.xml
+++ b/samples/samples-war/war-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-keycloak/pom.xml
+++ b/samples/samples-war/war-keycloak/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post-fragment-tomcat/pom.xml
+++ b/samples/samples-war/war-limited-post-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post-fragment-tomcat/pom.xml
+++ b/samples/samples-war/war-limited-post-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post-fragment-tomcat/pom.xml
+++ b/samples/samples-war/war-limited-post-fragment-tomcat/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post-fragment-undertow/pom.xml
+++ b/samples/samples-war/war-limited-post-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post-fragment-undertow/pom.xml
+++ b/samples/samples-war/war-limited-post-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post-fragment-undertow/pom.xml
+++ b/samples/samples-war/war-limited-post-fragment-undertow/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post/pom.xml
+++ b/samples/samples-war/war-limited-post/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post/pom.xml
+++ b/samples/samples-war/war-limited-post/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-limited-post/pom.xml
+++ b/samples/samples-war/war-limited-post/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-1/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-1/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-1/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-2/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-2/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-2/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-3/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-3/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-bundle-3/pom.xml
+++ b/samples/samples-war/war-most-complex/container-bundle-3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-fragment-1/pom.xml
+++ b/samples/samples-war/war-most-complex/container-fragment-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-fragment-1/pom.xml
+++ b/samples/samples-war/war-most-complex/container-fragment-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-fragment-1/pom.xml
+++ b/samples/samples-war/war-most-complex/container-fragment-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-fragment-2/pom.xml
+++ b/samples/samples-war/war-most-complex/container-fragment-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-fragment-2/pom.xml
+++ b/samples/samples-war/war-most-complex/container-fragment-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/container-fragment-2/pom.xml
+++ b/samples/samples-war/war-most-complex/container-fragment-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/pom.xml
+++ b/samples/samples-war/war-most-complex/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/pom.xml
+++ b/samples/samples-war/war-most-complex/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/pom.xml
+++ b/samples/samples-war/war-most-complex/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-fragment/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-fragment/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-fragment/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-fragment/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself-jar1/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself-jar1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself-jar1/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself-jar1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself-jar1/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself-jar1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself-jar2/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself-jar2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself-jar2/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself-jar2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself-jar2/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself-jar2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-itself/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-itself/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-jar/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-jar/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-jar/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-jar/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-most-complex/the-wab-jar/pom.xml
+++ b/samples/samples-war/war-most-complex/the-wab-jar/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-required/pom.xml
+++ b/samples/samples-war/war-required/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-required/pom.xml
+++ b/samples/samples-war/war-required/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-required/pom.xml
+++ b/samples/samples-war/war-required/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-requiring/pom.xml
+++ b/samples/samples-war/war-requiring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-requiring/pom.xml
+++ b/samples/samples-war/war-requiring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-requiring/pom.xml
+++ b/samples/samples-war/war-requiring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-security/pom.xml
+++ b/samples/samples-war/war-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-security/pom.xml
+++ b/samples/samples-war/war-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-security/pom.xml
+++ b/samples/samples-war/war-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-servlet-jsp-file/pom.xml
+++ b/samples/samples-war/war-servlet-jsp-file/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-servlet-jsp-file/pom.xml
+++ b/samples/samples-war/war-servlet-jsp-file/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-servlet-jsp-file/pom.xml
+++ b/samples/samples-war/war-servlet-jsp-file/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simple/pom.xml
+++ b/samples/samples-war/war-simple/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simple/pom.xml
+++ b/samples/samples-war/war-simple/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simple/pom.xml
+++ b/samples/samples-war/war-simple/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simplest-javaee/pom.xml
+++ b/samples/samples-war/war-simplest-javaee/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simplest-javaee/pom.xml
+++ b/samples/samples-war/war-simplest-javaee/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simplest-javaee/pom.xml
+++ b/samples/samples-war/war-simplest-javaee/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simplest-osgi/pom.xml
+++ b/samples/samples-war/war-simplest-osgi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simplest-osgi/pom.xml
+++ b/samples/samples-war/war-simplest-osgi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-simplest-osgi/pom.xml
+++ b/samples/samples-war/war-simplest-osgi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-spring-wired/pom.xml
+++ b/samples/samples-war/war-spring-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-spring-wired/pom.xml
+++ b/samples/samples-war/war-spring-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-spring-wired/pom.xml
+++ b/samples/samples-war/war-spring-wired/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-spring/pom.xml
+++ b/samples/samples-war/war-spring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-spring/pom.xml
+++ b/samples/samples-war/war-spring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-spring/pom.xml
+++ b/samples/samples-war/war-spring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-vaadin08-spring/pom.xml
+++ b/samples/samples-war/war-vaadin08-spring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-vaadin08-spring/pom.xml
+++ b/samples/samples-war/war-vaadin08-spring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-vaadin08-spring/pom.xml
+++ b/samples/samples-war/war-vaadin08-spring/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-vaadin08/pom.xml
+++ b/samples/samples-war/war-vaadin08/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-vaadin08/pom.xml
+++ b/samples/samples-war/war-vaadin08/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-vaadin08/pom.xml
+++ b/samples/samples-war/war-vaadin08/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-websocket-jsr356/pom.xml
+++ b/samples/samples-war/war-websocket-jsr356/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-websocket-jsr356/pom.xml
+++ b/samples/samples-war/war-websocket-jsr356/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war-websocket-jsr356/pom.xml
+++ b/samples/samples-war/war-websocket-jsr356/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war/pom.xml
+++ b/samples/samples-war/war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war/pom.xml
+++ b/samples/samples-war/war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-war/war/pom.xml
+++ b/samples/samples-war/war/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-war</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/pom.xml
+++ b/samples/samples-whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/pom.xml
+++ b/samples/samples-whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/pom.xml
+++ b/samples/samples-whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web</groupId>
 		<artifactId>samples</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-1/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-1/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-1/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-1/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-2/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-2/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-2/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-2/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-3/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-3/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-3/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-3/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-annotated/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-annotated/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-annotated/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-annotated/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-annotated/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-annotated/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-blueprint-jaxrs/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-blueprint-jaxrs/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-blueprint-jaxrs/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-blueprint-jaxrs/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-blueprint-jaxrs/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-blueprint-jaxrs/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-blueprint/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-blueprint/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-blueprint/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-blueprint/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-blueprint/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-blueprint/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-1603/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-1603/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-1603/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-1603/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-1603/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-1603/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-dynamic/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-dynamic/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-dynamic/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-dynamic/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-dynamic/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-dynamic/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-jaxrs/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-jaxrs/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-jaxrs/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-jaxrs/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds-jaxrs/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds-jaxrs/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-ds/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-ds/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-extended/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-extended/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-extended/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-extended/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-extended/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-extended/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-scopes/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-scopes/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-scopes/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-scopes/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-scopes/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-scopes/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-security/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-security/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard-security/pom.xml
+++ b/samples/samples-whiteboard/whiteboard-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard/pom.xml
+++ b/samples/samples-whiteboard/whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.33</version>
+		<version>8.0.34-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard/pom.xml
+++ b/samples/samples-whiteboard/whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34-SNAPSHOT</version>
+		<version>8.0.34</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/samples/samples-whiteboard/whiteboard/pom.xml
+++ b/samples/samples-whiteboard/whiteboard/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.ops4j.pax.web.samples</groupId>
 		<artifactId>samples-whiteboard</artifactId>
-		<version>8.0.34</version>
+		<version>8.0.35-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 


### PR DESCRIPTION
This PR makes it possible to define the `org.ops4j.pax.web.http.whiteboard.websocket` service property for servlets. The service must not longer be annotated with Endpoint.

